### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/docs/scripts/defineMap.js
+++ b/docs/scripts/defineMap.js
@@ -490,7 +490,8 @@ define([
         // see this link for more info: http://davidwalsh.name/fakepath
         name = name[0].replace("c:\\fakepath\\", "");
 
-        document.getElementById('upload-status').innerHTML = '<b>Loading </b>' + name;
+        const uploadStatus = document.getElementById('upload-status');
+        uploadStatus.textContent = 'Loading ' + name;
 
         // define the input params for generate see the rest doc for details
         // https://developers.arcgis.com/rest/users-groups-and-items/generate.htm


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/nr-seedtransfer-map/security/code-scanning/4](https://github.com/bcgov/nr-seedtransfer-map/security/code-scanning/4)

To fix the issue, the user-controlled input (`name`) must be sanitized or escaped before being inserted into the DOM. Instead of directly concatenating the `name` variable into the HTML string, we can use `textContent` to safely set the text content of the element, which ensures that any special characters in the input are escaped and treated as plain text rather than HTML.

Changes to make:
1. Replace the use of `innerHTML` with `textContent` for the `upload-status` element.
2. Update the code on line 493 to safely display the filename without interpreting it as HTML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
