### PR TITLE
fix(map): configure dojo packages to support subpaths for pr previews

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -64,3 +64,25 @@ jobs:
           branch: gh-pages
           clean: false # Do not delete other previews!
           target-folder: deployments/pr-${{ github.event.number }}
+
+      - name: 🧪 Smoke Test PR Preview URL
+        run: |
+          PREVIEW_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/deployments/pr-${{ github.event.number }}/index.html"
+          echo "📡 Checking if preview is live at $PREVIEW_URL"
+          TIMEOUT=180
+          INTERVAL=15
+          ELAPSED=0
+          
+          while [ $ELAPSED -lt $TIMEOUT ]; do
+            STATUS=$(curl -o /dev/null -s -w "%{http_code}" "$PREVIEW_URL" || true)
+            if [ "$STATUS" = "200" ]; then
+              echo "✅ Smoke test passed! Preview is live and returning HTTP 200."
+              exit 0
+            fi
+            echo "⏳ Status is $STATUS, retrying in ${INTERVAL}s... ($ELAPSED/$TIMEOUT)"
+            sleep $INTERVAL
+            ELAPSED=$((ELAPSED + INTERVAL))
+          done
+          
+          echo "❌ Timeout reached! Preview environment is not returning HTTP 200."
+          exit 1

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,6 +24,21 @@
     <script src="lib/bootstrap-table/js/bootstrap-table.min.js"></script>
 
     <!-- ArcGIS Maps SDK JS runtime loader remains on the Esri CDN due to dynamic lazy-loading Dojo modules -->
+    <script>
+      ;(function () {
+        var pathname = window.location.pathname
+        var locationPath = pathname.substring(0, pathname.lastIndexOf('/'))
+        window.dojoConfig = {
+          async: true,
+          packages: [
+            {
+              name: 'scripts',
+              location: locationPath + '/scripts',
+            },
+          ],
+        }
+      })()
+    </script>
     <script src="https://js.arcgis.com/4.30/"></script>
     <script src="scripts/requireMain.js" type="text/javascript"></script>
   </head>


### PR DESCRIPTION
Configure window.dojoConfig packages path in docs/index.html to dynamically resolve using location.pathname. This resolves subpath loading issues in PR deployment environments. Closes #49

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Map Preview](https://bcgov.github.io/nr-seedtransfer-map/deployments/pr-51/index.html)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-seedtransfer-map/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-seedtransfer-map/actions/workflows/merge.yml)