### PR TITLE
chore(ci): serialize gh-pages updates, optimize speed, and prune database

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -7,8 +7,8 @@ on:
       - 'docs/**'
 
 concurrency:
-  group: deploy-production
-  cancel-in-progress: true
+  group: gh-pages-state
+  cancel-in-progress: false
 
 permissions: {}
 

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [closed]
 
+concurrency:
+  group: gh-pages-state
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -68,6 +68,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Check if database has changed
+        id: db-check
+        run: |
+          git fetch origin main:main
+          if git diff --name-only main...HEAD | grep -q "^docs/Version_7_0/"; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "📂 Database changes detected. Keeping full database in deployment."
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "⚡ Database is unchanged. Pruning for speed."
+          fi
+      - name: Prune database if unchanged
+        if: steps.db-check.outputs.changed == 'false'
+        run: rm -rf docs/Version_7_0
       - name: Deploy to deployments/pr-${{ github.event.number }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -10,8 +10,8 @@ on:
       - 'playwright.config.js'
 
 concurrency:
-  group: pr-preview-${{ github.event.number }}
-  cancel-in-progress: true
+  group: gh-pages-state
+  cancel-in-progress: false
 
 permissions: {}
 

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -18,7 +18,7 @@ permissions: {}
 jobs:
   validate:
     name: Lint & Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
       - name: Set up Node.js
@@ -43,6 +43,17 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> $GITHUB_OUTPUT
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
       - name: Install Playwright Chromium & dependencies
         run: npx playwright install --with-deps chromium
       - name: Run E2E Integration tests

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -9,9 +9,11 @@ on:
       - 'package*.json'
       - 'playwright.config.js'
 
+# Workflow-level: per-PR cancellation so rapid pushes don't queue stale runs.
+# The deploy job adds its own gh-pages-state lock to serialize gh-pages mutations.
 concurrency:
-  group: gh-pages-state
-  cancel-in-progress: false
+  group: pr-preview-${{ github.event.number }}
+  cancel-in-progress: true
 
 permissions: {}
 
@@ -55,7 +57,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-playwright-
       - name: Install Playwright Chromium & dependencies
-        run: npx playwright install --with-deps chromium
+        run: |
+          if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
+            npx playwright install-deps chromium
+          else
+            npx playwright install --with-deps chromium
+          fi
       - name: Run E2E Integration tests
         run: npm run test:e2e
 
@@ -63,18 +70,22 @@ jobs:
     name: Deploy PR Preview
     needs: [validate, e2e]
     if: github.event.pull_request.head.repo.full_name == github.repository
+    # Serialize gh-pages mutations across pr-open, pr-close, and merge workflows.
+    concurrency:
+      group: gh-pages-state
+      cancel-in-progress: false
     permissions:
       contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
       - name: Check if database has changed
         id: db-check
         run: |
-          git fetch origin main:main
-          if git diff --name-only main...HEAD | grep -q "^docs/Version_7_0/"; then
+          git fetch --depth=1 origin main
+          # Two-dot diff: HEAD is the PR merge commit, so origin/main..HEAD is the PR's delta.
+          # Avoids needing a deep history for a merge-base (triple-dot).
+          if git diff --name-only origin/main HEAD | grep -q "^docs/Version_7_0/"; then
             echo "changed=true" >> $GITHUB_OUTPUT
             echo "📂 Database changes detected. Keeping full database in deployment."
           else

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -79,22 +79,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Check if database has changed
-        id: db-check
+      - name: Prune database if unchanged
         run: |
           git fetch --depth=1 origin main
           # Two-dot diff: HEAD is the PR merge commit, so origin/main..HEAD is the PR's delta.
           # Avoids needing a deep history for a merge-base (triple-dot).
           if git diff --name-only origin/main HEAD | grep -q "^docs/Version_7_0/"; then
-            echo "changed=true" >> $GITHUB_OUTPUT
             echo "📂 Database changes detected. Keeping full database in deployment."
           else
-            echo "changed=false" >> $GITHUB_OUTPUT
             echo "⚡ Database is unchanged. Pruning for speed."
+            rm -rf docs/Version_7_0
           fi
-      - name: Prune database if unchanged
-        if: steps.db-check.outputs.changed == 'false'
-        run: rm -rf docs/Version_7_0
       - name: Deploy to deployments/pr-${{ github.event.number }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/docs/scripts/main.js
+++ b/docs/scripts/main.js
@@ -284,8 +284,16 @@ define(function () {
   function fetchJSON(url) {
     return fetch(url).then(function (r) {
       if (!r.ok) {
-        // Fallback for PR Previews: if a local DB fetch fails (e.g. 404),
-        // try fetching from the stable production root database instead.
+        // Fallback for PR Previews: if a local DB fetch fails (e.g. 404 because
+        // pr-open.yml pruned docs/Version_7_0/ when the PR didn't touch it),
+        // retry against the stable production database at the gh-pages root.
+        //
+        // Assumes:
+        //   1. Previews live exactly two path segments deep: /deployments/pr-N/
+        //      so '../../' resolves to the gh-pages site root.
+        //   2. Everything under Version_7_0/ is JSON and loaded via fetchJSON().
+        //      If you add non-JSON assets there, either widen this fallback or
+        //      disable the prune step in .github/workflows/pr-open.yml.
         if (
           url.startsWith('Version_7_0/') &&
           window.location.pathname.includes('/deployments/pr-')

--- a/docs/scripts/main.js
+++ b/docs/scripts/main.js
@@ -421,18 +421,18 @@ define(function () {
               // ========= SUITABLE OUTPUT ======================
               if (output_suit.length > 0) {
                 for (let i = 0; i < output_suit.length; i++) {
-                  outlist_suit += "'" + output_suit[i].BECvar_seed + "'" + ', '
+                  outlist_suit.push("'" + output_suit[i].BECvar_seed + "'")
                 }
               }
-              outlist_suit = outlist_suit.slice(0, -2)
+              outlist_suit = outlist_suit.join(', ')
 
               // ========= NON SUITABLE OUTPUT ==========
               if (output_non_suit.length > 0) {
                 for (let i = 0; i < output_non_suit.length; i++) {
-                  outlist_non_suit += "'" + output_non_suit[i].BECvar_seed + "'" + ', '
+                  outlist_non_suit.push("'" + output_non_suit[i].BECvar_seed + "'")
                 }
               }
-              outlist_non_suit = outlist_non_suit.slice(0, -2)
+              outlist_non_suit = outlist_non_suit.join(', ')
 
               resolveInner(outlist_suit)
             } else {
@@ -484,10 +484,10 @@ define(function () {
               let t2 = getIntersection(output_suit).then(function (output) {
                 if (output.length > 0) {
                   for (let i = 0; i < output.length; i++) {
-                    outlist_suit += "'" + output[i].BECvar_seed + "'" + ', '
+                    outlist_suit.push("'" + output[i].BECvar_seed + "'")
                   }
                 }
-                outlist_suit = outlist_suit.slice(0, -2)
+                outlist_suit = outlist_suit.join(', ')
                 console.log(outlist_suit)
               })
 
@@ -495,10 +495,10 @@ define(function () {
                 // ========= NON SUITABLE OUTPUT ==========
                 if (output.length > 0) {
                   for (let i = 0; i < output.length; i++) {
-                    outlist_non_suit += "'" + output[i].BECvar_seed + "'" + ', '
+                    outlist_non_suit.push("'" + output[i].BECvar_seed + "'")
                   }
                 }
-                outlist_non_suit = outlist_non_suit.slice(0, -2)
+                outlist_non_suit = outlist_non_suit.join(', ')
                 console.log(outlist_non_suit)
               })
 

--- a/docs/scripts/main.js
+++ b/docs/scripts/main.js
@@ -284,6 +284,23 @@ define(function () {
   function fetchJSON(url) {
     return fetch(url).then(function (r) {
       if (!r.ok) {
+        // Fallback for PR Previews: if a local DB fetch fails (e.g. 404),
+        // try fetching from the stable production root database instead.
+        if (
+          url.startsWith('Version_7_0/') &&
+          window.location.pathname.includes('/deployments/pr-')
+        ) {
+          const fallbackUrl = '../../' + url
+          console.warn(
+            `Local database file not found at ${url}. Falling back to production database: ${fallbackUrl}`,
+          )
+          return fetch(fallbackUrl).then(function (fallbackR) {
+            if (!fallbackR.ok) {
+              throw new Error(fallbackR.statusText)
+            }
+            return fallbackR.json()
+          })
+        }
         throw new Error(r.statusText)
       }
       return r.json()


### PR DESCRIPTION
## Pull Request Overview

Three CI/CD problems, one PR:

1. **Race conditions on `gh-pages`** — `pr-close.yml` and `merge.yml` were racing each other (and `pr-open.yml`'s preview deploy) to push to the same branch, producing intermittent Git lock collisions and red badges.
2. **PR previews were uploading 476 MB of unchanged JSON** every time, even for one-line CSS tweaks.
3. **`outlist_suit`/`outlist_non_suit`** were declared as arrays, then mutated into strings via implicit `+=` coercion, then `.slice(0, -2)` to trim a stray trailing `", "`. Pure cursed.

### Changes

#### 1. Serialize only what needs serializing (`pr-open.yml`, `pr-close.yml`, `merge.yml`)
- Shared concurrency group `gh-pages-state` with `cancel-in-progress: false` on every job that pushes to `gh-pages` — queues writers instead of letting them collide.
- Scoped to the **`deploy` job only** in `pr-open.yml`. The workflow itself keeps `pr-preview-${{ github.event.number }}` + `cancel-in-progress: true` so rapid pushes to the same PR still cancel stale `validate`/`e2e` runs, and other PRs don't serialize behind unrelated work.

#### 2. Smart database pruning + 404 fallback (`pr-open.yml`, `docs/scripts/main.js`)
- New deploy step diffs `docs/Version_7_0/` against `origin/main` (two-dot, shallow fetch — no `fetch-depth: 0`, no local-ref divergence footgun). Single combined check-and-prune step, no inter-step plumbing.
- If unchanged: `rm -rf docs/Version_7_0` before upload → **476 MB to ~1.3 MB**.
- If changed: keep the folder so the PR previews its own DB edits in isolation.
- `fetchJSON()` in `main.js` catches 404s on `Version_7_0/*` requests when running under `/deployments/pr-*/` and transparently retries against the gh-pages root (`../../Version_7_0/`). Comment documents the two assumptions: 2-level preview path, JSON-only folder.

#### 3. Pipeline speed-ups (`pr-open.yml`)
- `validate` job moved to `ubuntu-slim` runner image.
- Playwright Chromium binary cached at `~/.cache/ms-playwright`, keyed by exact Playwright version. Saves ~30–40s on cache hit.
- On cache hit, `playwright install` skips `--with-deps` and only runs `install-deps chromium` (apt step), shaving more time.

#### 4. Outlist refactor (`docs/scripts/main.js`)
- Replaced the `[] += "string"` coercion + `.slice(0, -2)` pattern with proper `.push()` + `.join(', ')`. Same output, no anti-pattern, lint-friendly.

### Verification
- All 7 status checks green on latest commit: Lint & Unit Tests, E2E Playwright, Deploy PR Preview, CodeQL, Analyze (actions/JS-TS), Validate PR.
- Preview deploy + smoke test verified live.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Map Preview](https://bcgov.github.io/nr-seedtransfer-map/deployments/pr-57/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-seedtransfer-map/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-seedtransfer-map/actions/workflows/merge.yml)