### PR TITLE
feat(deps): track ArcGIS Maps SDK via Renovate customManager

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -10,7 +10,7 @@
       href="https://maps.forsite.ca/favicon/favicon-32x32.png"
     />
     <!-- ArcGIS Maps SDK and theme are kept on the Esri CDN due to its footprint (30MB+ of dynamic modules/WASM) -->
-    <link rel="stylesheet" href="https://js.arcgis.com/4.30/esri/themes/light/main.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/4.34/esri/themes/light/main.css" />
     <link rel="stylesheet" href="lib/bootstrap/css/bootstrap.min.css" />
     <link rel="stylesheet" href="lib/slim-select/slimselect.css" />
     <link href="css/styles.css" rel="stylesheet" type="text/css" />
@@ -37,7 +37,7 @@
         }
       })()
     </script>
-    <script src="https://js.arcgis.com/4.30/"></script>
+    <script src="https://js.arcgis.com/4.34/"></script>
     <script src="scripts/requireMain.js" type="text/javascript"></script>
   </head>
 

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,17 @@
   "description": "Repository-specific Renovate config. Extends the shared bcgov/renovate-config preset. Downstream repos should reference this file for consistent update management.",
   "extends": [
     "github>bcgov/renovate-config#2026.5.24"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track ArcGIS Maps SDK pinned in docs/index.html via @arcgis/core on npm (CDN URLs use MAJOR.MINOR; npm publishes full semver).",
+      "managerFilePatterns": ["/^docs/index\\.html$/"],
+      "matchStrings": ["https://js\\.arcgis\\.com/(?<currentValue>\\d+\\.\\d+)/"],
+      "depNameTemplate": "@arcgis/core",
+      "datasourceTemplate": "npm",
+      "versioningTemplate": "loose",
+      "extractVersionTemplate": "^(?<version>\\d+\\.\\d+)"
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -8,12 +8,21 @@
     {
       "customType": "regex",
       "description": "Track ArcGIS Maps SDK pinned in docs/index.html via @arcgis/core on npm (CDN URLs use MAJOR.MINOR; npm publishes full semver).",
-      "managerFilePatterns": ["/^docs/index\\.html$/"],
+      "managerFilePatterns": ["docs/index.html"],
       "matchStrings": ["https://js\\.arcgis\\.com/(?<currentValue>\\d+\\.\\d+)/"],
       "depNameTemplate": "@arcgis/core",
       "datasourceTemplate": "npm",
       "versioningTemplate": "loose",
       "extractVersionTemplate": "^(?<version>\\d+\\.\\d+)"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Cap ArcGIS Maps SDK CDN pin to 4.x; 5.x is a separate major-bump migration.",
+      "matchDatasources": ["npm"],
+      "matchPackageNames": ["@arcgis/core"],
+      "matchFileNames": ["docs/index.html"],
+      "allowedVersions": "<5.0.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a Renovate `customManagers` regex entry that tracks the hand-pinned ArcGIS Maps SDK version in `docs/index.html`
- Uses `@arcgis/core` on npm as the datasource (Esri has no GitHub releases; npm publishes mirror CDN versions exactly)
- `extractVersionTemplate` strips the patch so the CDN's `MAJOR.MINOR` URL format is preserved when Renovate writes back
- Bumps the pin from `4.30` to `4.34` (latest stable in the 4.x line)

## Notes
- ArcGIS 5.0 is also available on the CDN/npm but is a major version bump worth its own PR/migration review — staying on 4.x here
- Regex verified locally against `docs/index.html`: matches both the CSS link and the script src (2 hits, both `4.34` post-bump)
- `renovate-config-validator` passes on the updated `renovate.json`

## Test plan
- After merge, watch the Renovate dependency dashboard (#44) for `@arcgis/core` to show up under custom managers
- Next minor bump (4.35, etc.) should auto-PR

Closes #60

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Map Preview](https://bcgov.github.io/nr-seedtransfer-map/deployments/pr-65/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-seedtransfer-map/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-seedtransfer-map/actions/workflows/merge.yml)