### PR TITLE
chore(ci): use ubuntu-slim for PR preview deploy

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -76,7 +76,7 @@ jobs:
       cancel-in-progress: false
     permissions:
       contents: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
       - name: Prune database if unchanged


### PR DESCRIPTION
## Summary
- Aligns the PR-preview deploy runner with the production deploy runner
- `merge.yml` already uses `ubuntu-slim` for the identical `JamesIves/github-pages-deploy-action` step; `pr-open.yml` was on `ubuntu-latest` for no documented reason
- Saves a few seconds per PR and removes a stale inconsistency

## Scope
- `e2e` job stays on `ubuntu-latest` — Playwright needs the full image
- `validate` job already uses `ubuntu-slim`

## Test plan
- This PR's own preview deploy is the test. If the slim runner can't handle the deploy step, this PR will fail and tell us.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Map Preview](https://bcgov.github.io/nr-seedtransfer-map/deployments/pr-66/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-seedtransfer-map/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-seedtransfer-map/actions/workflows/merge.yml)