### PR TITLE
fix(ui): bump version label from 6.0 to 7.0

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>CBST Seedlot Selection Tool Version 6.0</title>
+    <title>CBST Seedlot Selection Tool Version 7.0</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <link
@@ -53,7 +53,7 @@
                 width="165"
                 height="64"
               />
-              <span id="titleText"> CBST Seedlot Selection Tool Version 6.0 </span>
+              <span id="titleText"> CBST Seedlot Selection Tool Version 7.0 </span>
               <span id="titleTextsmall">
                 CBST Areas of Use as per the April 2022 Amendments to the Chief Forester’s Standards
                 for Seed Use, [BEC 10]


### PR DESCRIPTION
## Summary
- Updates the browser tab title and page header from \`Version 6.0\` to \`Version 7.0\` in \`docs/index.html\`
- The seedlot data has been shipping from \`docs/Version_7_0/\` but the user-visible label was stale

## Scope
- Two string changes only (\`<title>\` and \`#titleText\` span)
- No tests assert on the version string (verified with grep)

## Test plan
- Open the PR preview, confirm the tab title and header both read \"Version 7.0\"

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Map Preview](https://bcgov.github.io/nr-seedtransfer-map/deployments/pr-67/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-seedtransfer-map/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-seedtransfer-map/actions/workflows/merge.yml)