### PR TITLE
feat(security): add Content-Security-Policy meta tag

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,19 @@
     <title>CBST Seedlot Selection Tool Version 7.0</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="
+        default-src 'self';
+        script-src 'self' https://js.arcgis.com 'unsafe-eval';
+        style-src 'self' 'unsafe-inline' https://js.arcgis.com;
+        img-src 'self' data: blob: https://*.arcgis.com https://*.arcgisonline.com https://maps.forsite.ca;
+        connect-src 'self' https://*.arcgis.com https://*.arcgisonline.com https://maps.forsite.ca;
+        font-src 'self' https://js.arcgis.com;
+        worker-src 'self' blob:;
+        child-src 'self' blob:;
+      "
+    />
     <link
       rel="shortcut icon"
       type="image/png"
@@ -22,79 +35,7 @@
     <script src="lib/bootstrap-table/js/bootstrap-table.min.js"></script>
 
     <!-- ArcGIS Maps SDK JS runtime loader remains on the Esri CDN due to dynamic lazy-loading Dojo modules -->
-    <script>
-      // Intercept and silence the expected internal Esri FeatureLayer load error for "Area of Use"
-      // to keep the developer console 100% clean of expected public deployment warnings.
-      const originalConsoleError = console.error
-      console.error = function (...args) {
-        let hasFailedToLoad = false
-        let hasAreaOfUse = false
-
-        args.forEach(function (arg) {
-          if (!arg) return
-          const str = String(arg)
-          if (str.indexOf('Failed to load layer') !== -1 || str.indexOf('FeatureLayer') !== -1) {
-            hasFailedToLoad = true
-          }
-          if (str.indexOf('Area of Use') !== -1) {
-            hasAreaOfUse = true
-          }
-          // Check object properties
-          if (typeof arg === 'object') {
-            try {
-              const json = JSON.stringify(arg)
-              if (json.indexOf('Area of Use') !== -1) {
-                hasAreaOfUse = true
-              }
-              if (json.indexOf('Failed to load layer') !== -1) {
-                hasFailedToLoad = true
-              }
-            } catch (e) {
-              // Circular object fallback: inspect common fields
-              if (
-                arg.title === 'Area of Use' ||
-                arg.name === 'Area of Use' ||
-                arg.message === 'Area of Use'
-              ) {
-                hasAreaOfUse = true
-              }
-              if (arg.message && arg.message.indexOf('Failed to load layer') !== -1) {
-                hasFailedToLoad = true
-              }
-            }
-          }
-        })
-
-        if (hasFailedToLoad && hasAreaOfUse) {
-          return
-        }
-        originalConsoleError.apply(console, args)
-      }
-
-      // Monkeypatch the missing reposition method on HTMLElement prototype to prevent
-      // internal Calcite Components / Stencil asynchronous upgrade race condition crashes
-      // where Esri CDN code calls popoverEl?.value?.reposition() before the element is fully upgraded.
-      if (typeof HTMLElement.prototype.reposition !== 'function') {
-        HTMLElement.prototype.reposition = function () {
-          console.debug('Calcite Components custom element reposition placeholder called.')
-        }
-      }
-
-      ;(function () {
-        var pathname = window.location.pathname
-        var locationPath = pathname.substring(0, pathname.lastIndexOf('/'))
-        window.dojoConfig = {
-          async: true,
-          cacheBust: 'v=7.0.5',
-          packages: [
-            {
-              name: 'scripts',
-              location: locationPath + '/scripts',
-            },
-          ],
-        }
-      })()
-    </script>
+    <script src="scripts/loader-init.js?v=7.0.5" type="text/javascript"></script>
     <script src="https://js.arcgis.com/4.34/"></script>
     <script type="module" src="https://js.arcgis.com/4.34/map-components/"></script>
     <script src="scripts/requireMain.js?v=7.0.5" type="text/javascript"></script>

--- a/docs/scripts/loader-init.js
+++ b/docs/scripts/loader-init.js
@@ -1,63 +1,63 @@
 // Intercept and silence the expected internal Esri FeatureLayer load error for "Area of Use"
 // to keep the developer console 100% clean of expected public deployment warnings.
-const originalConsoleError = console.error;
+const originalConsoleError = console.error
 console.error = function (...args) {
-  let hasFailedToLoad = false;
-  let hasAreaOfUse = false;
+  let hasFailedToLoad = false
+  let hasAreaOfUse = false
 
   args.forEach(function (arg) {
-    if (!arg) return;
-    const str = String(arg);
+    if (!arg) return
+    const str = String(arg)
     if (str.indexOf('Failed to load layer') !== -1 || str.indexOf('FeatureLayer') !== -1) {
-      hasFailedToLoad = true;
+      hasFailedToLoad = true
     }
     if (str.indexOf('Area of Use') !== -1) {
-      hasAreaOfUse = true;
+      hasAreaOfUse = true
     }
     // Check object properties
     if (typeof arg === 'object') {
       try {
-        const json = JSON.stringify(arg);
+        const json = JSON.stringify(arg)
         if (json.indexOf('Area of Use') !== -1) {
-          hasAreaOfUse = true;
+          hasAreaOfUse = true
         }
         if (json.indexOf('Failed to load layer') !== -1) {
-          hasFailedToLoad = true;
+          hasFailedToLoad = true
         }
-      } catch (e) {
+      } catch {
         // Circular object fallback: inspect common fields
         if (
           arg.title === 'Area of Use' ||
           arg.name === 'Area of Use' ||
           arg.message === 'Area of Use'
         ) {
-          hasAreaOfUse = true;
+          hasAreaOfUse = true
         }
         if (arg.message && arg.message.indexOf('Failed to load layer') !== -1) {
-          hasFailedToLoad = true;
+          hasFailedToLoad = true
         }
       }
     }
-  });
+  })
 
   if (hasFailedToLoad && hasAreaOfUse) {
-    return;
+    return
   }
-  originalConsoleError.apply(console, args);
-};
+  originalConsoleError.apply(console, args)
+}
 
 // Monkeypatch the missing reposition method on HTMLElement prototype to prevent
 // internal Calcite Components / Stencil asynchronous upgrade race condition crashes
 // where Esri CDN code calls popoverEl?.value?.reposition() before the element is fully upgraded.
 if (typeof HTMLElement.prototype.reposition !== 'function') {
   HTMLElement.prototype.reposition = function () {
-    console.debug('Calcite Components custom element reposition placeholder called.');
-  };
+    console.debug('Calcite Components custom element reposition placeholder called.')
+  }
 }
 
-(function () {
-  var pathname = window.location.pathname;
-  var locationPath = pathname.substring(0, pathname.lastIndexOf('/'));
+;(function () {
+  var pathname = window.location.pathname
+  var locationPath = pathname.substring(0, pathname.lastIndexOf('/'))
   window.dojoConfig = {
     async: true,
     cacheBust: 'v=7.0.5',
@@ -67,5 +67,5 @@ if (typeof HTMLElement.prototype.reposition !== 'function') {
         location: locationPath + '/scripts',
       },
     ],
-  };
-})();
+  }
+})()

--- a/docs/scripts/loader-init.js
+++ b/docs/scripts/loader-init.js
@@ -1,0 +1,71 @@
+// Intercept and silence the expected internal Esri FeatureLayer load error for "Area of Use"
+// to keep the developer console 100% clean of expected public deployment warnings.
+const originalConsoleError = console.error;
+console.error = function (...args) {
+  let hasFailedToLoad = false;
+  let hasAreaOfUse = false;
+
+  args.forEach(function (arg) {
+    if (!arg) return;
+    const str = String(arg);
+    if (str.indexOf('Failed to load layer') !== -1 || str.indexOf('FeatureLayer') !== -1) {
+      hasFailedToLoad = true;
+    }
+    if (str.indexOf('Area of Use') !== -1) {
+      hasAreaOfUse = true;
+    }
+    // Check object properties
+    if (typeof arg === 'object') {
+      try {
+        const json = JSON.stringify(arg);
+        if (json.indexOf('Area of Use') !== -1) {
+          hasAreaOfUse = true;
+        }
+        if (json.indexOf('Failed to load layer') !== -1) {
+          hasFailedToLoad = true;
+        }
+      } catch (e) {
+        // Circular object fallback: inspect common fields
+        if (
+          arg.title === 'Area of Use' ||
+          arg.name === 'Area of Use' ||
+          arg.message === 'Area of Use'
+        ) {
+          hasAreaOfUse = true;
+        }
+        if (arg.message && arg.message.indexOf('Failed to load layer') !== -1) {
+          hasFailedToLoad = true;
+        }
+      }
+    }
+  });
+
+  if (hasFailedToLoad && hasAreaOfUse) {
+    return;
+  }
+  originalConsoleError.apply(console, args);
+};
+
+// Monkeypatch the missing reposition method on HTMLElement prototype to prevent
+// internal Calcite Components / Stencil asynchronous upgrade race condition crashes
+// where Esri CDN code calls popoverEl?.value?.reposition() before the element is fully upgraded.
+if (typeof HTMLElement.prototype.reposition !== 'function') {
+  HTMLElement.prototype.reposition = function () {
+    console.debug('Calcite Components custom element reposition placeholder called.');
+  };
+}
+
+(function () {
+  var pathname = window.location.pathname;
+  var locationPath = pathname.substring(0, pathname.lastIndexOf('/'));
+  window.dojoConfig = {
+    async: true,
+    cacheBust: 'v=7.0.5',
+    packages: [
+      {
+        name: 'scripts',
+        location: locationPath + '/scripts',
+      },
+    ],
+  };
+})();


### PR DESCRIPTION
Adds Content-Security-Policy meta tag to docs/index.html and extracts the setup scripts into docs/scripts/loader-init.js to secure the static app without needing unsafe-inline scripts. Closes #63

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Map Preview](https://bcgov.github.io/nr-seedtransfer-map/deployments/pr-73/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-seedtransfer-map/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-seedtransfer-map/actions/workflows/merge.yml)