### PR TITLE
chore(data): source seedlot data currency date dynamically

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -41,7 +41,7 @@
     <script src="scripts/requireMain.js?v=7.0.5" type="text/javascript"></script>
   </head>
 
-  <body>
+  <body data-seedlot-date="August 18th, 2025">
     <div id="ctn" class="container-fluid g-0">
       <div class="row g-0 bg-light fixed-top" id="titleRow">
         <nav class="col-12">
@@ -59,8 +59,9 @@
                 for Seed Use, [BEC 10]
               </span>
               <br />
-              <span class="titleTextsmall" class="align-text-top">
-                Seedlot Data Current as of August 18th, 2025
+              <span class="titleTextsmall align-text-top">
+                Seedlot Data Current as of
+                <span class="seedlot-data-date-placeholder">August 18th, 2025</span>
               </span>
             </div>
           </div>
@@ -158,8 +159,11 @@
                     species and BEC variant values for you. Otherwise leave blank.
                   </li>
                   <li>
-                    Seedlot data refreshed August 18th, 2025. Seedlots that have been registered on
-                    SPAR after August 18th, 2025 are not included in the tool
+                    Seedlot data refreshed
+                    <span class="seedlot-data-date-placeholder">August 18th, 2025</span>. Seedlots
+                    that have been registered on SPAR after
+                    <span class="seedlot-data-date-placeholder">August 18th, 2025</span> are not
+                    included in the tool
                   </li>
                   <li>
                     Some B Class seedlots are not yet included in the tool (pending their assignment

--- a/docs/scripts/requireMain.js
+++ b/docs/scripts/requireMain.js
@@ -1,5 +1,11 @@
 require(['scripts/defineMap.js', 'scripts/main.js'], function (defineMap, main) {
   $(function () {
+    const seedlotDate = document.body.getAttribute('data-seedlot-date')
+    if (seedlotDate) {
+      document.querySelectorAll('.seedlot-data-date-placeholder').forEach(function (el) {
+        el.textContent = seedlotDate
+      })
+    }
     main.fillSelects()
     setTimeout(function () {
       defineMap.mapInit()

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -14,6 +14,38 @@ test.describe('CBST Seedlot Selection Tool - E2E Integration Tests', () => {
     await expect(page.locator('#titleText')).toContainText('CBST Seedlot Selection Tool')
   })
 
+  test('Sourcing: Sourced seedlot data-currency date is dynamically populated from body data attribute', async ({
+    page,
+  }) => {
+    // 1. Verify the default date renders correctly in both places
+    const subtitle = page.locator('#titleDiv .titleTextsmall.align-text-top')
+    await expect(subtitle).toContainText('Seedlot Data Current as of August 18th, 2025')
+
+    // Click the instructions tab to ensure visibility
+    await page.click('#instructions-tab')
+    const instructionItem = page.locator('#instructions ul.card-text li').filter({ hasText: 'Seedlot data refreshed' })
+    await expect(instructionItem).toContainText(
+      'Seedlot data refreshed August 18th, 2025. Seedlots that have been registered on SPAR after August 18th, 2025 are not included in the tool'
+    )
+
+    // 2. Change the body data-seedlot-date attribute and propagate to verify dynamic updates
+    await page.evaluate(() => {
+      document.body.setAttribute('data-seedlot-date', 'December 25th, 2026')
+      const seedlotDate = document.body.getAttribute('data-seedlot-date')
+      if (seedlotDate) {
+        document.querySelectorAll('.seedlot-data-date-placeholder').forEach(function (el) {
+          el.textContent = seedlotDate
+        })
+      }
+    })
+
+    // Assert that the text dynamically updated to the new date in all placeholders
+    await expect(subtitle).toContainText('Seedlot Data Current as of December 25th, 2026')
+    await expect(instructionItem).toContainText(
+      'Seedlot data refreshed December 25th, 2026. Seedlots that have been registered on SPAR after December 25th, 2026 are not included in the tool'
+    )
+  })
+
   test('Cutblock Flow: Selecting FDI species and IDFdk1 BEC variant populates tables', async ({
     page,
   }) => {


### PR DESCRIPTION
Sources the seedlot data-currency date dynamically from a single custom data attribute on the body tag in index.html to avoid duplicate hardcoded strings drifting.

Closes #61

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Map Preview](https://bcgov.github.io/nr-seedtransfer-map/deployments/pr-74/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-seedtransfer-map/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-seedtransfer-map/actions/workflows/merge.yml)