### PR TITLE
feat(cleanup): remove deprecated and unused 2019 map layers

### DIFF
--- a/docs/scripts/defineMap.js
+++ b/docs/scripts/defineMap.js
@@ -29,7 +29,7 @@ define([
   var _scaleBar
   var activeWidget
   var expand, trackWidget
-  var currentLayer, nonsuitLayer, _current2019Layer, _nonsuit2019Layer, mguLayer
+  var currentLayer, nonsuitLayer, mguLayer
   var _suitRenderer, _nonSuitRenderer
   var portalUrl = 'https://www.arcgis.com'
   var template
@@ -126,16 +126,7 @@ define([
       ['map_label', 'SHAPE_Area'],
       'CBST Species May Not Be Suitable',
     )
-    _current2019Layer = featureInit(
-      'https://maps.forsite.ca/server/rest/services/Hosted/CBST_BEC10_BEC11/FeatureServer/2',
-      ['map_label', 'SHAPE_Area'],
-      'CBST 2019',
-    )
-    _nonsuit2019Layer = featureInit(
-      'https://maps.forsite.ca/server/rest/services/Hosted/CBST_BEC10_BEC11/FeatureServer/3',
-      ['map_label', 'SHAPE_Area'],
-      '2019 Species May Not Be Suitable',
-    )
+
     mguLayer = featureInit(
       'https://maps.forsite.ca/server/rest/services/Hosted/CBST_BEC10_BEC11/FeatureServer/0',
       ['Management_Units'],


### PR DESCRIPTION
## Summary

This PR cleans up deprecated and unused map layers as requested in Issue #52. 

## Context

Per Issue #42, the swap to the new B.C. Government Map Hub (ArcGIS Online) layers is currently blocked because the new layers are set to private (triggering a login screen). 

However, we can safely perform the preparatory cleanup outlined in **Issue #52** today by deleting the deprecated 2019 layers that are completely dead code:
* `_current2019Layer`
* `_nonsuit2019Layer`

## Changes

- Removed variable definitions and feature layer initializations for `_current2019Layer` and `_nonsuit2019Layer` from `defineMap.js`.
- These layers were previously initialized from external Forsite server endpoints but were never added to the map or used anywhere else in the application.

## Verification

- Running unit tests: `npm run test:unit` (Passed)
- Running E2E tests: `npm run test:e2e` (Passed)

Addresses #52

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Map Preview](https://bcgov.github.io/nr-seedtransfer-map/deployments/pr-80/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-seedtransfer-map/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-seedtransfer-map/actions/workflows/merge.yml)