### PR TITLE
feat(csp/seedlot): fix CSP violations, prune 404s, and add vegetative seedlot support

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -2,7 +2,7 @@ name: Merge Deployment
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
       - 'docs/**'
 
@@ -13,7 +13,23 @@ concurrency:
 permissions: {}
 
 jobs:
+  validate:
+    name: Lint & Unit Tests
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Verify syntax, formatting & run unit tests
+        run: npm run validate
+
   deploy:
+    needs: [validate]
     permissions:
       contents: write
     runs-on: ubuntu-slim

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -89,6 +89,7 @@ jobs:
           else
             echo "⚡ Database is unchanged. Pruning for speed."
             rm -rf docs/Version_7_0
+            sed -i 's/<body/<body data-database-pruned="true"/g' docs/index.html
           fi
       - name: Deploy to deployments/pr-${{ github.event.number }}
         uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -47,7 +47,9 @@ jobs:
         run: npm ci
       - name: Get Playwright version
         id: playwright-version
-        run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> $GITHUB_OUTPUT
+        run:
+          echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")"
+          >> $GITHUB_OUTPUT
       - name: Cache Playwright browsers
         uses: actions/cache@v5
         id: playwright-cache
@@ -89,7 +91,7 @@ jobs:
           else
             echo "⚡ Database is unchanged. Pruning for speed."
             rm -rf docs/Version_7_0
-            sed -i 's/<body/<body data-database-pruned="true"/g' docs/index.html
+            sed -i 's/<body/<body data-database-pruned="true"/' docs/index.html
           fi
       - name: Deploy to deployments/pr-${{ github.event.number }}
         uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4
@@ -106,7 +108,7 @@ jobs:
           TIMEOUT=300
           INTERVAL=15
           ELAPSED=0
-          
+
           while [ $ELAPSED -lt $TIMEOUT ]; do
             STATUS=$(curl -o /dev/null -s -w "%{http_code}" "$PREVIEW_URL" || true)
             if [ "$STATUS" = "200" ]; then
@@ -117,6 +119,6 @@ jobs:
             sleep $INTERVAL
             ELAPSED=$((ELAPSED + INTERVAL))
           done
-          
+
           echo "❌ Timeout reached! Preview environment is not returning HTTP 200."
           exit 1

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -47,9 +47,8 @@ jobs:
         run: npm ci
       - name: Get Playwright version
         id: playwright-version
-        run:
-          echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")"
-          >> $GITHUB_OUTPUT
+        run: |
+          echo "version=$(node -e 'console.log(require("@playwright/test/package.json").version)')" >> $GITHUB_OUTPUT
       - name: Cache Playwright browsers
         uses: actions/cache@v5
         id: playwright-cache

--- a/README.md
+++ b/README.md
@@ -160,12 +160,19 @@ nr-seedtransfer-map/
 
 ## Expected Console Warnings & Suppressions
 
-To ensure a clean, distraction-free developer experience, our client-side runtime contains a console interceptor in `loader-init.js` that intercepts and silences expected external CDN/map-service errors.
+To ensure a clean, distraction-free developer experience, our client-side runtime contains a console
+interceptor in `loader-init.js` that intercepts and silences expected external CDN/map-service
+errors.
 
 ### Suppressed Errors:
+
 1. **Esri CDN Tile Load Failures**:
-   - **Signature**: `[esri.views.2d.layers.features.FeatureSourceEventLog] Failed to load tile <coords>.`
-   - **Reason**: The map layers loaded from `maps.forsite.ca` are hosted feature services. Under high zoom levels or in certain bounds, some query tiles return 5xx errors from the server. The ArcGIS Maps SDK self-heals these failures automatically (by falling back or retrying), so these warnings are safe to silence.
+   - **Signature**:
+     `[esri.views.2d.layers.features.FeatureSourceEventLog] Failed to load tile <coords>.`
+   - **Reason**: The map layers loaded from `maps.forsite.ca` are hosted feature services. Under
+     high zoom levels or in certain bounds, some query tiles return 5xx errors from the server. The
+     ArcGIS Maps SDK self-heals these failures automatically (by falling back or retrying), so these
+     warnings are safe to silence.
    - **Impact**: Purely cosmetic; silenced to avoid red console spam.
 
 ---

--- a/README.md
+++ b/README.md
@@ -158,6 +158,18 @@ nr-seedtransfer-map/
 
 ---
 
+## Expected Console Warnings & Suppressions
+
+To ensure a clean, distraction-free developer experience, our client-side runtime contains a console interceptor in `loader-init.js` that intercepts and silences expected external CDN/map-service errors.
+
+### Suppressed Errors:
+1. **Esri CDN Tile Load Failures**:
+   - **Signature**: `[esri.views.2d.layers.features.FeatureSourceEventLog] Failed to load tile <coords>.`
+   - **Reason**: The map layers loaded from `maps.forsite.ca` are hosted feature services. Under high zoom levels or in certain bounds, some query tiles return 5xx errors from the server. The ArcGIS Maps SDK self-heals these failures automatically (by falling back or retrying), so these warnings are safe to silence.
+   - **Impact**: Purely cosmetic; silenced to avoid red console spam.
+
+---
+
 ## License & Contributions
 
 This application is built for the **Province of British Columbia** and is open to contributions.

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -59,35 +59,8 @@ body {
   white-space: nowrap;
 }
 
-#formDiv {
-  width: 100%;
-}
-
 .esri-item-list__scroller {
   overflow-y: visible;
-}
-
-.list-heading {
-  text-align: center;
-  font-weight: normal;
-  margin-top: 10px;
-  margin-bottom: 10px;
-  color: #323232;
-}
-
-.or-wrap {
-  background-color: #e0e0e0;
-  height: 1px;
-  margin: 2em 0;
-  overflow: visible;
-}
-
-.or-text {
-  background: #fff;
-  line-height: 0;
-  padding: 0 1em;
-  position: relative;
-  bottom: 0.75em;
 }
 
 /* override default styles */
@@ -120,17 +93,6 @@ body {
   height: 100%;
 }
 
-.no-gutters {
-  margin-right: 0;
-  margin-left: 0;
-
-  > .col,
-  > [class*='col-'] {
-    padding-right: 0;
-    padding-left: 0;
-  }
-}
-
 #titleRow {
   height: 90px;
   border-bottom: 1px solid #dee2e6;
@@ -147,11 +109,6 @@ body {
 #titleText {
   width: 100%;
   font-size: 1.5em;
-  font-weight: 500;
-}
-
-#titleTextsmall {
-  font-size: 1em;
   font-weight: 500;
 }
 
@@ -174,10 +131,6 @@ body {
   top: 20px;
   right: 20px;
   z-index: 999;
-}
-
-#scaleText {
-  font: bold 12px arial;
 }
 
 /*#grid {

--- a/docs/index.html
+++ b/docs/index.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" href="https://js.arcgis.com/4.34/esri/themes/light/main.css" />
     <link rel="stylesheet" href="lib/bootstrap/css/bootstrap.min.css" />
     <link rel="stylesheet" href="lib/slim-select/slimselect.css" />
-    <link href="css/styles.css?v=7.0.6" rel="stylesheet" type="text/css" />
+    <link href="css/styles.css?v=7.0.7" rel="stylesheet" type="text/css" />
 
     <script src="lib/jquery/jquery.min.js"></script>
     <script src="lib/bootstrap/js/bootstrap.bundle.min.js"></script>
@@ -35,14 +35,14 @@
     <script src="lib/bootstrap-table/js/bootstrap-table.min.js"></script>
 
     <!-- ArcGIS Maps SDK JS runtime loader remains on the Esri CDN due to dynamic lazy-loading Dojo modules -->
-    <script src="scripts/loader-init.js?v=7.0.6" type="text/javascript"></script>
+    <script src="scripts/loader-init.js?v=7.0.7" type="text/javascript"></script>
     <script src="https://js.arcgis.com/4.34/"></script>
     <script type="module" src="https://js.arcgis.com/4.34/map-components/"></script>
     <script
       type="module"
       src="https://js.arcgis.com/calcite-components/3.3.2/calcite.esm.js"
     ></script>
-    <script src="scripts/requireMain.js?v=7.0.6" type="text/javascript"></script>
+    <script src="scripts/requireMain.js?v=7.0.7" type="text/javascript"></script>
   </head>
 
   <body data-seedlot-date="August 18th, 2025">

--- a/docs/index.html
+++ b/docs/index.html
@@ -365,7 +365,7 @@
                     <b>OR</b>
                     <div class="mb-3">
                       <label for="seedlotNumber">Seedlot Number: </label><br />
-                      <input id="seedlotNumber" type="number" class="form-control" /><br />
+                      <input id="seedlotNumber" type="text" class="form-control" /><br />
                     </div>
                     <button id="addSpeciesBecSeedlot" type="button" class="btn btn-secondary mb-3">
                       Set Species & BEC</button

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <title>CBST Seedlot Selection Tool Version 7.0</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
@@ -27,11 +27,11 @@
     <link rel="stylesheet" href="lib/bootstrap/css/bootstrap.min.css" />
     <link rel="stylesheet" href="lib/slim-select/slimselect.css" />
     <link href="css/styles.css?v=7.0.8" rel="stylesheet" type="text/css" />
+    <link rel="stylesheet" href="lib/bootstrap-table/css/bootstrap-table.min.css" />
 
     <script src="lib/jquery/jquery.min.js"></script>
     <script src="lib/bootstrap/js/bootstrap.bundle.min.js"></script>
     <script src="lib/slim-select/slimselect.min.js"></script>
-    <link rel="stylesheet" href="lib/bootstrap-table/css/bootstrap-table.min.css" />
     <script src="lib/bootstrap-table/js/bootstrap-table.min.js"></script>
 
     <!-- ArcGIS Maps SDK JS runtime loader remains on the Esri CDN due to dynamic lazy-loading Dojo modules -->
@@ -73,7 +73,7 @@
                   <span class="d-none d-md-inline">CBST Seedlot Selection Tool Version 7.0</span>
                   <span class="d-md-none">CBST Seedlot Tool</span>
                 </span>
-                <span id="titleTextsmall" class="d-none d-md-inline-block ms-2 text-muted fs-6">
+                <span class="titleTextsmall d-none d-md-inline-block ms-2 text-muted fs-6">
                   CBST Areas of Use as per the April 2022 Amendments to the Chief Forester’s
                   Standards for Seed Use, [BEC 10]
                 </span>
@@ -279,7 +279,7 @@
                   role="tabpanel"
                   aria-labelledby="cutblock-tab"
                 >
-                  <form>
+                  <form aria-label="Cutblock species and BEC variant selection">
                     <div class="mb-3">
                       <label for="speciesInputCutblock">Species: </label><br />
                       <select class="form-select" id="speciesInputCutblock"></select>
@@ -298,22 +298,7 @@
                       Clear
                     </button>
                   </form>
-                  <hr class="my-4" />
-                  <div class="mb-3">
-                    <label for="coordsforlocation_cutblock" class="form-label font-weight-bold"
-                      >Zoom to Location (Lat,Long):</label
-                    >
-                    <input
-                      id="coordsforlocation_cutblock"
-                      type="text"
-                      class="form-control"
-                      placeholder="e.g. 54.123, -125.456"
-                    />
-                  </div>
-                  <button id="btnUpdate_cutblock" type="button" class="btn btn-secondary w-100">
-                    Zoom to Location
-                  </button>
-                  <p></p>
+
                   <div id="grid"></div>
                   <br />
                   <div id="seedlotgrid"></div>
@@ -345,6 +330,21 @@
                       </thead>
                     </table>
                   </div>
+                  <hr class="my-4" />
+                  <div class="mb-3">
+                    <label for="coordsforlocation_cutblock" class="form-label fw-bold"
+                      >Zoom to Location (Lat,Long):</label
+                    >
+                    <input
+                      id="coordsforlocation_cutblock"
+                      type="text"
+                      class="form-control"
+                      placeholder="e.g. 54.123, -125.456"
+                    />
+                  </div>
+                  <button id="btnUpdate_cutblock" type="button" class="btn btn-secondary w-100">
+                    Zoom to Location
+                  </button>
                 </div>
                 <div
                   title="I Have a Seedlot"
@@ -353,10 +353,10 @@
                   role="tabpanel"
                   aria-labelledby="seedlot-tab"
                 >
-                  <form>
+                  <form aria-label="Seedlot species and BEC variant selection">
                     <div class="mb-3">
                       <label for="orchardNumber">Orchard Number: </label><br />
-                      <input id="orchardNumber" type="number" class="form-control" />
+                      <input id="orchardNumber" type="number" class="form-control" min="0" />
                     </div>
                     <button id="addSeedlotfromOrchard" type="button" class="btn btn-secondary mb-3">
                       Set Representative Seedlot</button
@@ -390,8 +390,8 @@
                         <tr>
                           <th data-field="BECvar_site" data-sortable="true">Plantation BEC</th>
                           <th data-field="BECvar_seed" data-sortable="true">Seed BEC</th>
-                          <th data-field="Sp_suit_seed">Suitability</th>
-                          <th data-field="Limit">Limit</th>
+                          <th data-field="Sp_suit_seed" data-sortable="true">Suitability</th>
+                          <th data-field="Limit" data-sortable="true">Limit</th>
                           <!-- <th data-field="override">OverRide</th> -->
                         </tr>
                       </thead>
@@ -403,7 +403,7 @@
                   <div id="messages"></div>
                   <hr class="my-4" />
                   <div class="mb-3">
-                    <label for="coordsforlocation_seedlot" class="form-label font-weight-bold"
+                    <label for="coordsforlocation_seedlot" class="form-label fw-bold"
                       >Zoom to Location (Lat,Long):</label
                     >
                     <input
@@ -438,7 +438,13 @@
                 <div class="field">
                   <label class="file-upload">
                     <span><strong>Add File</strong></span>
-                    <input class="inputupload" type="file" name="file" id="inFile" />
+                    <input
+                      class="inputupload"
+                      type="file"
+                      name="file"
+                      id="inFile"
+                      aria-label="Upload KML or GeoJSON file"
+                    />
                   </label>
                 </div>
               </form>

--- a/docs/index.html
+++ b/docs/index.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" href="https://js.arcgis.com/4.34/esri/themes/light/main.css" />
     <link rel="stylesheet" href="lib/bootstrap/css/bootstrap.min.css" />
     <link rel="stylesheet" href="lib/slim-select/slimselect.css" />
-    <link href="css/styles.css?v=7.0.7" rel="stylesheet" type="text/css" />
+    <link href="css/styles.css?v=7.0.8" rel="stylesheet" type="text/css" />
 
     <script src="lib/jquery/jquery.min.js"></script>
     <script src="lib/bootstrap/js/bootstrap.bundle.min.js"></script>
@@ -35,14 +35,14 @@
     <script src="lib/bootstrap-table/js/bootstrap-table.min.js"></script>
 
     <!-- ArcGIS Maps SDK JS runtime loader remains on the Esri CDN due to dynamic lazy-loading Dojo modules -->
-    <script src="scripts/loader-init.js?v=7.0.7" type="text/javascript"></script>
+    <script src="scripts/loader-init.js?v=7.0.8" type="text/javascript"></script>
     <script src="https://js.arcgis.com/4.34/"></script>
     <script type="module" src="https://js.arcgis.com/4.34/map-components/"></script>
     <script
       type="module"
       src="https://js.arcgis.com/calcite-components/3.3.2/calcite.esm.js"
     ></script>
-    <script src="scripts/requireMain.js?v=7.0.7" type="text/javascript"></script>
+    <script src="scripts/requireMain.js?v=7.0.8" type="text/javascript"></script>
   </head>
 
   <body data-seedlot-date="August 18th, 2025">

--- a/docs/index.html
+++ b/docs/index.html
@@ -291,20 +291,10 @@
                       <select class="form-select" multiple id="becInputCutblock"></select>
                     </div>
 
-                    <button
-                      id="addButtonCutblock"
-                      type="submit"
-                      class="btn btn-secondary"
-                      onclick="return false"
-                    >
+                    <button id="addButtonCutblock" type="button" class="btn btn-secondary">
                       GO
                     </button>
-                    <button
-                      id="clearButtonCutblock"
-                      type="submit"
-                      class="btn btn-secondary"
-                      onclick="return false"
-                    >
+                    <button id="clearButtonCutblock" type="button" class="btn btn-secondary">
                       Clear
                     </button>
                   </form>
@@ -390,13 +380,7 @@
                       <select class="form-select" multiple id="becInputSeedlot"></select>
                     </div>
                     <br />
-                    <button
-                      id="addButtonSeedlot"
-                      type="submit"
-                      class="btn btn-secondary"
-                      onclick="return false"
-                    >
-                      GO</button
+                    <button id="addButtonSeedlot" type="button" class="btn btn-secondary">GO</button
                     ><br />
                     <br />
                   </form>

--- a/docs/scripts/defineMap.js
+++ b/docs/scripts/defineMap.js
@@ -12,7 +12,6 @@ define([
   'esri/request',
   'esri/layers/support/Field',
   'esri/Graphic',
-  'esri/layers/KMLLayer',
 ], function (
   Map,
   MapView,
@@ -23,7 +22,6 @@ define([
   request,
   Field,
   Graphic,
-  KMLLayer,
 ) {
   var map, view, xy
   var _scaleBar
@@ -36,22 +34,7 @@ define([
   var uploadFormEl, uploadStatusEl
 
   template = {
-    title: 'Selected {MAP_Label}',
-  }
-
-  _suitRenderer = {
-    type: 'simple-fill',
-    color: [217, 95, 2, 0.4],
-    outline: {
-      color: [115, 76, 0, 1],
-    },
-  }
-  _nonSuitRenderer = {
-    type: 'simple-fill',
-    color: [170, 102, 205, 0.4],
-    outline: {
-      color: [76, 0, 115, 1],
-    },
+    title: 'Selected {MAP_LABEL}',
   }
 
   return {
@@ -60,7 +43,6 @@ define([
     clearLyrs: clearLyrs,
     addLayers: addLayers,
     updateLayer: updateLayer,
-    updatePopup: updatePopup,
     clearCutBlock: clearCutBlock,
   }
 
@@ -91,7 +73,6 @@ define([
 
     // Make the layers
     layerInit()
-    updatePopup()
 
     addExpand()
     addTracking()
@@ -102,8 +83,6 @@ define([
       view.ui.add('topbar', 'top-left')
       view.ui.add(expand, 'top-left')
       view.ui.add(trackWidget, 'top-left')
-
-      const _attributeEditing = document.getElementById('featureUpdateDiv')
 
       addBasemapGallery()
       addPrintButton()
@@ -148,14 +127,13 @@ define([
   function updateLayer(outlist) {
     // outlist: all 4 possible queries that reflect the users chosen species and bec variant
     // outlist = [outlist_suit, outlist_non_suit, outlist_2019, outlist_non_2019]
-    window.outlist = outlist
 
     if (outlist[1].length != 0) {
       nonsuitLayer.definitionExpression = 'MAP_LABEL in (' + outlist[1] + ')'
       nonsuitLayer.popupTemplate = template
       map.add(nonsuitLayer)
     } else {
-      nonsuitLayer.definitionExpression = 'MAP_LABEL in ()'
+      nonsuitLayer.definitionExpression = '1=0'
       nonsuitLayer.popupTemplate = ''
       map.add(nonsuitLayer)
     }
@@ -165,7 +143,7 @@ define([
       currentLayer.popupTemplate = template
       map.add(currentLayer)
     } else {
-      currentLayer.definitionExpression = 'MAP_LABEL in ()'
+      currentLayer.definitionExpression = '1=0'
       currentLayer.popupTemplate = ''
       map.add(currentLayer)
     }
@@ -173,20 +151,6 @@ define([
     if (mguLayer.loadStatus === 'loaded') {
       map.add(mguLayer)
     }
-  }
-
-  function updatePopup() {
-    nonsuitLayer.on('selection-complete', (event) => {
-      // Round coordinates to 3 decimals
-      const lat = Math.round(event.mapPoint.latitude * 1000) / 1000
-      const lon = Math.round(event.mapPoint.longitude * 1000) / 1000
-
-      view.popup.open({
-        // Set the popup's title to the coordinates of the clicked location
-        title: 'Reverse geocode: [' + lon + ', ' + lat + ']',
-        location: event.mapPoint, // Set the location of the popup to the clicked location
-      })
-    })
   }
 
   /*
@@ -207,7 +171,7 @@ define([
     var layer = new FeatureLayer({
       url: src,
       title: name,
-      outfields: fields,
+      outFields: fields,
       opacity: 0.5,
       visibilityMode: 'independent',
     })
@@ -215,43 +179,6 @@ define([
       console.warn('Failed to load feature layer: ' + name, error)
     })
     return layer
-  }
-
-  function _kmlInit(src) {
-    return new KMLLayer({
-      url: src,
-      title: 'KML Sample',
-    })
-  }
-
-  // Initialize a feature layer with definition query and custom renderer
-  function _featureInit_complex(src, expression, name, renderer) {
-    return new FeatureLayer({
-      url: src,
-      definitionExpression: expression,
-      title: name,
-      renderer: renderer,
-      opacity: 0.5,
-      visibilityMode: 'independent',
-    })
-  }
-
-  /*
-   * Utility Functions
-   */
-  function _popupTable(lyr) {
-    lyr.load().then(function () {
-      lyr.popupTemplate = lyr.createPopupTemplate()
-    })
-  }
-
-  function _updateKey(list) {
-    var listLength = list.length
-    var newlist = new Array()
-    for (let i = 0; i < listLength; i++) {
-      newlist.push(list[i][1].replace(/ /g, '_'))
-    }
-    return newlist
   }
 
   function fullExtent() {
@@ -264,35 +191,6 @@ define([
   /*
    * Widgets and behaviour
    */
-
-  // Add the line and area measurement tools
-  function _addMeasurement() {
-    document.getElementById('distanceButton').addEventListener('click', function () {
-      setActiveWidget(null)
-      if (!this.classList.contains('active')) {
-        setActiveWidget('distance')
-        view.focus()
-      } else {
-        setActiveButton(null)
-      }
-    })
-    document.getElementById('areaButton').addEventListener('click', function () {
-      setActiveWidget(null)
-      if (!this.classList.contains('active')) {
-        setActiveWidget('area')
-        view.focus()
-      } else {
-        setActiveButton(null)
-      }
-    })
-  }
-
-  /*Create and add the extent button widget*/
-  function _addExtentButton() {
-    document.getElementById('homeButton').addEventListener('click', function () {
-      fullExtent()
-    })
-  }
 
   function addTracking() {
     trackWidget = document.createElement('arcgis-track')
@@ -462,48 +360,12 @@ define([
     }
   }
 
-  function _addMouseCoord() {
-    var coordsWidget = document.createElement('mouseDiv')
-    coordsWidget.id = 'coordsWidget'
-    coordsWidget.className = 'esri-widget esri-component'
-    view.ui.add(coordsWidget, 'bottom-right')
-    function showCoordinates(pt) {
-      var coords =
-        'Lat/Long ' +
-        pt.latitude.toFixed(3) +
-        ' ' +
-        pt.longitude.toFixed(3) +
-        ' | Scale 1:' +
-        Math.round(view.scale * 1) / 1
-      coordsWidget.innerHTML = coords
-    }
-
-    view.watch('stationary', function (_isStationary) {
-      showCoordinates(view.center)
-    })
-    view.on('pointer-move', function (evt) {
-      showCoordinates(view.toMap({ x: evt.x, y: evt.y }))
-    })
-  }
-
   // Add the basemap gallery
   function addBasemapGallery() {
     document.getElementById('basemapButton').addEventListener('click', function () {
       setActiveWidget(null)
       if (!this.classList.contains('active')) {
         setActiveWidget('basemap')
-      } else {
-        setActiveButton(null)
-      }
-    })
-  }
-
-  // Add the instructions button
-  function _addLogo() {
-    document.getElementById('instructionButton').addEventListener('click', function () {
-      setActiveWidget(null)
-      if (!this.classList.contains('active')) {
-        setActiveWidget('instruction')
       } else {
         setActiveButton(null)
       }
@@ -544,8 +406,7 @@ define([
   function setActiveWidget(type) {
     switch (type) {
       case 'home':
-        activeWidget = fullExtent()
-        view.ui.add(activeWidget)
+        fullExtent()
         setActiveButton(document.getElementById('homeButton'))
         break
       case 'basemap':

--- a/docs/scripts/defineMap.js
+++ b/docs/scripts/defineMap.js
@@ -125,8 +125,8 @@ define([
   }
 
   function updateLayer(outlist) {
-    // outlist: all 4 possible queries that reflect the users chosen species and bec variant
-    // outlist = [outlist_suit, outlist_non_suit, outlist_2019, outlist_non_2019]
+    // outlist: definition query strings that reflect the user's chosen species and BEC variant
+    // outlist = [outlist_suit, outlist_non_suit]
 
     if (outlist[1].length != 0) {
       nonsuitLayer.definitionExpression = 'MAP_LABEL in (' + outlist[1] + ')'

--- a/docs/scripts/loader-init.js
+++ b/docs/scripts/loader-init.js
@@ -1,3 +1,53 @@
+// Intercept and silence expected Esri CDN hosted FeatureLayer tile loading errors
+// (e.g. Failed to load tile) that happen on the maps.forsite.ca server
+// to keep the developer console 100% clean of expected warnings.
+const originalConsoleError = console.error
+const originalConsoleWarn = console.warn
+
+function isEsriTileError(args) {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    if (!arg) continue
+    const str = String(arg)
+    if (
+      str.indexOf('Failed to load tile') !== -1 ||
+      str.indexOf('FeatureSourceEventLog') !== -1
+    ) {
+      return true
+    }
+    if (typeof arg === 'object') {
+      try {
+        const json = JSON.stringify(arg)
+        if (
+          json.indexOf('Failed to load tile') !== -1 ||
+          json.indexOf('FeatureSourceEventLog') !== -1
+        ) {
+          return true
+        }
+      } catch {
+        if (
+          arg.message &&
+          (arg.message.indexOf('Failed to load tile') !== -1 ||
+            arg.message.indexOf('FeatureSourceEventLog') !== -1)
+        ) {
+          return true
+        }
+      }
+    }
+  }
+  return false
+}
+
+console.error = function (...args) {
+  if (isEsriTileError(args)) return
+  originalConsoleError.apply(console, args)
+}
+
+console.warn = function (...args) {
+  if (isEsriTileError(args)) return
+  originalConsoleWarn.apply(console, args)
+}
+
 // Monkeypatch the missing reposition method on HTMLElement prototype to prevent
 // internal Calcite Components / Stencil asynchronous upgrade race condition crashes
 // where Esri CDN code calls popoverEl?.value?.reposition() before the element is fully upgraded.
@@ -12,7 +62,7 @@ if (typeof HTMLElement.prototype.reposition !== 'function') {
   var locationPath = pathname.substring(0, pathname.lastIndexOf('/'))
   window.dojoConfig = {
     async: true,
-    cacheBust: 'v=7.0.7',
+    cacheBust: 'v=7.0.8',
     packages: [
       {
         name: 'scripts',

--- a/docs/scripts/loader-init.js
+++ b/docs/scripts/loader-init.js
@@ -12,7 +12,7 @@ if (typeof HTMLElement.prototype.reposition !== 'function') {
   var locationPath = pathname.substring(0, pathname.lastIndexOf('/'))
   window.dojoConfig = {
     async: true,
-    cacheBust: 'v=7.0.6',
+    cacheBust: 'v=7.0.7',
     packages: [
       {
         name: 'scripts',

--- a/docs/scripts/loader-init.js
+++ b/docs/scripts/loader-init.js
@@ -9,10 +9,7 @@ function isEsriTileError(args) {
     const arg = args[i]
     if (!arg) continue
     const str = String(arg)
-    if (
-      str.indexOf('Failed to load tile') !== -1 ||
-      str.indexOf('FeatureSourceEventLog') !== -1
-    ) {
+    if (str.indexOf('Failed to load tile') !== -1 || str.indexOf('FeatureSourceEventLog') !== -1) {
       return true
     }
     if (typeof arg === 'object') {

--- a/docs/scripts/main.js
+++ b/docs/scripts/main.js
@@ -743,7 +743,7 @@ define(function () {
             return x['Orchard'] == orch || parseFloat(x['Orchard']) == parseFloat(orch)
           })
           if (seedlot.length > 0) {
-            document.getElementById('seedlotNumber').value = parseInt(seedlot[0].Seedlot)
+            document.getElementById('seedlotNumber').value = seedlot[0].Seedlot.toString()
 
             fetchJSON(jsonseed)
               .then(function (seed_data) {

--- a/docs/scripts/main.js
+++ b/docs/scripts/main.js
@@ -393,7 +393,12 @@ define(function () {
     if (!sp || sp === '') {
       return Promise.reject(new Error('Please select a Species.'))
     }
-    if (!bec || bec.length === 0) {
+    if (
+      !bec ||
+      bec.length === 0 ||
+      bec === '' ||
+      (Array.isArray(bec) && (bec.length === 0 || bec[0] === ''))
+    ) {
       return Promise.reject(new Error('Please select a BEC Variant.'))
     }
 
@@ -666,7 +671,7 @@ define(function () {
     if (!sp || sp === '') {
       return Promise.reject(new Error('Please select a Species.'))
     }
-    if (!bec || bec === '') {
+    if (!bec || bec === '' || (Array.isArray(bec) && (bec.length === 0 || bec[0] === ''))) {
       return Promise.reject(new Error('Please select a BEC Variant.'))
     }
 

--- a/docs/scripts/main.js
+++ b/docs/scripts/main.js
@@ -370,7 +370,8 @@ define(function () {
     }
 
     var outlist_suit, outlist_non_suit
-    var output_suit, output_non_suit
+    var output_suit = [],
+      output_non_suit = []
     var bec_name
 
     var jsontxt =
@@ -398,17 +399,21 @@ define(function () {
         .then(function (data) {
           var results = []
 
-          let becPromise = new Promise((resolveInner) => {
+          let becPromise = new Promise((resolveInner, rejectInner) => {
             if (bec.length == 1) {
               var becEntry = becStore.find((x) => x.id == bec)
               if (!becEntry) {
-                reject(new Error('Unknown BEC variant ID: ' + bec))
+                rejectInner(new Error('Unknown BEC variant ID: ' + bec))
                 return
               }
               bec_name = becEntry.name
               results = data.filter(function (x) {
                 return x['BECvar_site'] == bec_name && x['HTp_pred'] >= suit
               })
+              if (results.length == 0) {
+                rejectInner(new Error('No results available for those parameters'))
+                return
+              }
               output_suit = data.filter(function (x) {
                 return (
                   x['BECvar_site'] == bec_name && x['HTp_pred'] >= suit && x['Sp_suit_site'] == 1
@@ -445,7 +450,7 @@ define(function () {
               for (let i = 0; i < bec.length; i++) {
                 var becEntryMulti = becStore.find((x) => x.id == bec[i])
                 if (!becEntryMulti) {
-                  reject(new Error('Unknown BEC variant ID: ' + bec[i]))
+                  rejectInner(new Error('Unknown BEC variant ID: ' + bec[i]))
                   return
                 }
                 bec_name = becEntryMulti.name
@@ -504,18 +509,26 @@ define(function () {
                 outlist_non_suit = outlist_non_suit.join(', ')
               })
 
-              Promise.all([t1, t2, t3]).then(() => {
-                resolveInner(results)
-              })
+              Promise.all([t1, t2, t3])
+                .then(() => {
+                  resolveInner(results)
+                })
+                .catch((err) => {
+                  rejectInner(err)
+                })
             }
           }).then(function () {
-            return [[outlist_suit], [outlist_non_suit]]
+            return [outlist_suit, outlist_non_suit]
           })
 
           resolve(becPromise)
         })
         .catch(function (errorThrown) {
-          reject(new Error('Failed to load Species database: ' + errorThrown.message))
+          if (errorThrown.message === 'No results available for those parameters') {
+            reject(errorThrown)
+          } else {
+            reject(new Error('Failed to load Species database: ' + errorThrown.message))
+          }
         })
     })
 
@@ -719,7 +732,11 @@ define(function () {
           resolve([outlist_suit, outlist_non_suit])
         })
         .catch(function (errorThrown) {
-          reject(new Error('Failed to load Species database: ' + errorThrown.message))
+          if (errorThrown.message === 'No results available for those parameters') {
+            reject(errorThrown)
+          } else {
+            reject(new Error('Failed to load Species database: ' + errorThrown.message))
+          }
         })
     })
   }

--- a/docs/scripts/main.js
+++ b/docs/scripts/main.js
@@ -730,7 +730,7 @@ define(function () {
       fetchJSON(jsonorch)
         .then(function (orch_data) {
           var seedlot = orch_data.filter(function (x) {
-            return x['Orchard'] == orch
+            return x['Orchard'] == orch || parseFloat(x['Orchard']) == parseFloat(orch)
           })
           if (seedlot.length > 0) {
             document.getElementById('seedlotNumber').value = parseInt(seedlot[0].Seedlot)
@@ -739,7 +739,7 @@ define(function () {
               .then(function (seed_data) {
                 new Promise((resolveInner) => {
                   results = seed_data.filter(function (x) {
-                    return x['Orchard'] == orch
+                    return x['Orchard'] == orch || parseFloat(x['Orchard']) == parseFloat(orch)
                   })
                   resolveInner(results)
                 }).then(() => {
@@ -794,6 +794,8 @@ define(function () {
               ? becStore.find((x) => x.name === results[0].BECvar)
               : null
             document.getElementById('orchardNumber').value = results[0].Orchard
+              ? parseFloat(results[0].Orchard).toString()
+              : ''
             if (window.selectBecSeedlot) {
               if (becVarObj) {
                 window.selectBecSeedlot.setSelected(becVarObj.id.toString())

--- a/docs/scripts/main.js
+++ b/docs/scripts/main.js
@@ -744,13 +744,23 @@ define(function () {
                   resolveInner(results)
                 }).then(() => {
                   window.res = results
-                  let becVar = becStore.find((x) => x.name == results[0].BECvar).id
-                  if (window.selectBecSeedlot) {
-                    window.selectBecSeedlot.setSelected(becVar.toString())
-                  }
+                  if (results && results.length > 0) {
+                    let becVarObj = results[0].BECvar
+                      ? becStore.find((x) => x.name == results[0].BECvar)
+                      : null
+                    if (window.selectBecSeedlot) {
+                      if (becVarObj) {
+                        window.selectBecSeedlot.setSelected(becVarObj.id.toString())
+                      } else {
+                        window.selectBecSeedlot.setSelected([])
+                      }
+                    }
 
-                  if (window.selectSpeciesSeedlot) {
-                    window.selectSpeciesSeedlot.setSelected(results[0].Species)
+                    if (window.selectSpeciesSeedlot && results[0].Species) {
+                      window.selectSpeciesSeedlot.setSelected(results[0].Species)
+                    }
+                  } else {
+                    console.warn(`No seedlots found in Seedlot_list.json for Orchard ${orch}`)
                   }
 
                   resolve()
@@ -780,12 +790,18 @@ define(function () {
             return x['Seedlot'] == lot
           })
           if (results && results.length > 0) {
-            let becVar = becStore.find((x) => x.name === results[0].BECvar).id
+            let becVarObj = results[0].BECvar
+              ? becStore.find((x) => x.name === results[0].BECvar)
+              : null
             document.getElementById('orchardNumber').value = results[0].Orchard
             if (window.selectBecSeedlot) {
-              window.selectBecSeedlot.setSelected(becVar.toString())
+              if (becVarObj) {
+                window.selectBecSeedlot.setSelected(becVarObj.id.toString())
+              } else {
+                window.selectBecSeedlot.setSelected([])
+              }
             }
-            if (window.selectSpeciesSeedlot) {
+            if (window.selectSpeciesSeedlot && results[0].Species) {
               window.selectSpeciesSeedlot.setSelected(results[0].Species)
             }
             resolve()

--- a/docs/scripts/main.js
+++ b/docs/scripts/main.js
@@ -281,7 +281,17 @@ define(function () {
    *    as a standard promise rejection to be caught and displayed by the UI error banner.
    */
   function fetchJSON(url) {
-    return fetch(url).then(function (r) {
+    const isDbPruned = document.body.getAttribute('data-database-pruned') === 'true'
+    let targetUrl = url
+    if (
+      isDbPruned &&
+      url.startsWith('Version_7_0/') &&
+      window.location.pathname.includes('/deployments/pr-')
+    ) {
+      targetUrl = '../../' + url
+    }
+
+    return fetch(targetUrl).then(function (r) {
       if (!r.ok) {
         // Fallback for PR Previews: if a local DB fetch fails (e.g. 404 because
         // pr-open.yml pruned docs/Version_7_0/ when the PR didn't touch it),
@@ -294,12 +304,12 @@ define(function () {
         //      If you add non-JSON assets there, either widen this fallback or
         //      disable the prune step in .github/workflows/pr-open.yml.
         if (
-          url.startsWith('Version_7_0/') &&
+          targetUrl.startsWith('Version_7_0/') &&
           window.location.pathname.includes('/deployments/pr-')
         ) {
-          const fallbackUrl = '../../' + url
+          const fallbackUrl = '../../' + targetUrl
           console.warn(
-            `Local database file not found at ${url}. Falling back to production database: ${fallbackUrl}`,
+            `Local database file not found at ${targetUrl}. Falling back to production database: ${fallbackUrl}`,
           )
           return fetch(fallbackUrl).then(function (fallbackR) {
             if (!fallbackR.ok) {

--- a/docs/scripts/main.js
+++ b/docs/scripts/main.js
@@ -3,8 +3,6 @@
  */
 
 define(function () {
-  var jsontxt, jsonseedlot
-
   var speciesStore = [
     { name: 'AT', minsuit: 97.5 },
     { name: 'BA', minsuit: 97.5 },
@@ -30,12 +28,6 @@ define(function () {
     { name: 'SX', minsuit: 97.5 },
     { name: 'SXS', minsuit: 97.5 },
     { name: 'YC', minsuit: 96.0 },
-  ]
-
-  var _gensuitdata = [
-    { gensuit: '1', classA: '1 to 0.98', classB: '1 to 0.985' },
-    { gensuit: '2', classA: '0.98 to 0.965', classB: '0.985 to 0.975' },
-    { gensuit: '3', classA: '0.965 to 0.955', classB: '0.975 to 0.965' },
   ]
 
   var becStore = [
@@ -293,31 +285,6 @@ define(function () {
 
     return fetch(targetUrl).then(function (r) {
       if (!r.ok) {
-        // Fallback for PR Previews: if a local DB fetch fails (e.g. 404 because
-        // pr-open.yml pruned docs/Version_7_0/ when the PR didn't touch it),
-        // retry against the stable production database at the gh-pages root.
-        //
-        // Assumes:
-        //   1. Previews live exactly two path segments deep: /deployments/pr-N/
-        //      so '../../' resolves to the gh-pages site root.
-        //   2. Everything under Version_7_0/ is JSON and loaded via fetchJSON().
-        //      If you add non-JSON assets there, either widen this fallback or
-        //      disable the prune step in .github/workflows/pr-open.yml.
-        if (
-          targetUrl.startsWith('Version_7_0/') &&
-          window.location.pathname.includes('/deployments/pr-')
-        ) {
-          const fallbackUrl = '../../' + targetUrl
-          console.warn(
-            `Local database file not found at ${targetUrl}. Falling back to production database: ${fallbackUrl}`,
-          )
-          return fetch(fallbackUrl).then(function (fallbackR) {
-            if (!fallbackR.ok) {
-              throw new Error(fallbackR.statusText)
-            }
-            return fallbackR.json()
-          })
-        }
         throw new Error(r.statusText)
       }
       return r.json()
@@ -326,7 +293,7 @@ define(function () {
 
   // adds all the options to the Species and BEC Variant dropdowns
   function fillSelects() {
-    for (const i in becStore) {
+    for (let i = 0; i < becStore.length; i++) {
       const temp = document.createElement('option')
       temp.label = becStore[i].name
       temp.value = becStore[i].id
@@ -338,7 +305,7 @@ define(function () {
       document.getElementById('becInputCutblock').options.add(temp)
       document.getElementById('becInputSeedlot').options.add(temp3)
     }
-    for (const j in speciesStore) {
+    for (let j = 0; j < speciesStore.length; j++) {
       const temp2 = document.createElement('option')
       temp2.value = speciesStore[j].name
       temp2.label = speciesStore[j].name
@@ -402,31 +369,27 @@ define(function () {
       return Promise.reject(new Error('Please select a BEC Variant.'))
     }
 
-    var spmin
-    var outlist_suit, outlist_non_suit, outlist_2019, outlist_non_2019
+    var outlist_suit, outlist_non_suit
     var output_suit, output_non_suit
     var bec_name
 
-    jsontxt =
+    var jsontxt =
       'Version_7_0/' +
       sp.charAt(0).toUpperCase() +
       sp.slice(1).toLowerCase() +
       '_migrated_height_list_5.json'
-    jsonseedlot =
+    var jsonseedlot =
       'Version_7_0/' + sp.charAt(0).toUpperCase() + sp.slice(1).toLowerCase() + '_Seedlots.json'
-    let suit = speciesStore.find((x) => x.name === sp).minsuit
+    let speciesEntry = speciesStore.find((x) => x.name === sp)
+    if (!speciesEntry) {
+      return Promise.reject(new Error('Unknown species: ' + sp))
+    }
+    let suit = speciesEntry.minsuit
 
     suit = suit / 100
-    spmin = 0
-    spmin = spmin / 100
-    window.dat = becStore
 
     outlist_suit = []
     outlist_non_suit = []
-    outlist_2019 = []
-    outlist_non_2019 = []
-    output_suit = []
-    output_non_suit = []
 
     let p1 = getSeedLot(bec, suit, 0, jsonseedlot)
 
@@ -437,13 +400,14 @@ define(function () {
 
           let becPromise = new Promise((resolveInner) => {
             if (bec.length == 1) {
-              bec_name = becStore.find((x) => x.id == bec).name
+              var becEntry = becStore.find((x) => x.id == bec)
+              if (!becEntry) {
+                reject(new Error('Unknown BEC variant ID: ' + bec))
+                return
+              }
+              bec_name = becEntry.name
               results = data.filter(function (x) {
-                return (
-                  x['BECvar_site'] == bec_name &&
-                  x['HTp_pred'] >= suit &&
-                  x['Sp_suit_site'] >= spmin
-                )
+                return x['BECvar_site'] == bec_name && x['HTp_pred'] >= suit
               })
               output_suit = data.filter(function (x) {
                 return (
@@ -479,14 +443,15 @@ define(function () {
               resolveInner(outlist_suit)
             } else {
               for (let i = 0; i < bec.length; i++) {
-                bec_name = becStore.find((x) => x.id == bec[i]).name
+                var becEntryMulti = becStore.find((x) => x.id == bec[i])
+                if (!becEntryMulti) {
+                  reject(new Error('Unknown BEC variant ID: ' + bec[i]))
+                  return
+                }
+                bec_name = becEntryMulti.name
                 results.push(
                   data.filter(function (x) {
-                    return (
-                      x['BECvar_site'] == bec_name &&
-                      x['HTp_pred'] >= suit &&
-                      x['Sp_suit_site'] >= spmin
-                    )
+                    return x['BECvar_site'] == bec_name && x['HTp_pred'] >= suit
                   }),
                 )
                 output_suit.push(
@@ -511,7 +476,7 @@ define(function () {
 
               let t1 = getIntersection(results).then(function (intersection) {
                 if (intersection.length == 0) {
-                  alert('No results available for those parameters')
+                  throw new Error('No results available for those parameters')
                 }
                 return updateData(intersection).then(function (data2) {
                   populateCutblockTable(data2)
@@ -544,7 +509,7 @@ define(function () {
               })
             }
           }).then(function () {
-            return [[outlist_suit], [outlist_non_suit], [outlist_2019], [outlist_non_2019]]
+            return [[outlist_suit], [outlist_non_suit]]
           })
 
           resolve(becPromise)
@@ -600,14 +565,24 @@ define(function () {
           let finalPromise
 
           if (bec.length == 1) {
-            bec_name = becStore.find((x) => x.id == bec).name
+            var becEntrySeed = becStore.find((x) => x.id == bec)
+            if (!becEntrySeed) {
+              reject(new Error('Unknown BEC variant ID: ' + bec))
+              return
+            }
+            bec_name = becEntrySeed.name
             results = data.filter(function (x) {
               return x['BECvar_site'] == bec_name && x['MigrationDistance'] >= spmin
             })
             finalPromise = Promise.resolve(results)
           } else {
             for (let i = 0; i < bec.length; i++) {
-              bec_name = becStore.find((x) => x.id == bec[i]).name
+              var becEntrySeedMulti = becStore.find((x) => x.id == bec[i])
+              if (!becEntrySeedMulti) {
+                reject(new Error('Unknown BEC variant ID: ' + bec[i]))
+                return
+              }
+              bec_name = becEntrySeedMulti.name
               results.push(
                 data.filter(function (x) {
                   return x['BECvar_site'] == bec_name && x['MigrationDistance'] >= spmin
@@ -647,14 +622,16 @@ define(function () {
 
   function updateData(data) {
     let new_res = new Promise(function (resolve) {
-      for (let i = 0; i < data.length; i++) {
-        if (data[i].Sp_suit_seed == '1') {
-          data[i].Sp_suit_seed = 'Suitable'
+      let clonedData = data.map((item) => {
+        let newItem = { ...item }
+        if (newItem.Sp_suit_seed == '1') {
+          newItem.Sp_suit_seed = 'Suitable'
         } else {
-          data[i].Sp_suit_seed = 'Not Suitable'
+          newItem.Sp_suit_seed = 'Not Suitable'
         }
-      }
-      resolve(data)
+        return newItem
+      })
+      resolve(clonedData)
     })
 
     return new_res
@@ -675,39 +652,36 @@ define(function () {
       return Promise.reject(new Error('Please select a BEC Variant.'))
     }
 
-    var spmin
-    var outlist_suit, outlist_non_suit, outlist_2019, outlist_non_2019
+    var outlist_suit, outlist_non_suit
     var output_suit, output_non_suit
 
-    jsontxt =
+    var jsontxt =
       'Version_7_0/' +
       sp.charAt(0).toUpperCase() +
       sp.slice(1).toLowerCase() +
       '_migrated_height_list_5.json'
-    jsonseedlot =
-      'Version_7_0/' + sp.charAt(0).toUpperCase() + sp.slice(1).toLowerCase() + '_Seedlots.json'
-    let suit = speciesStore.find((x) => x.name === sp).minsuit
+    let speciesEntry = speciesStore.find((x) => x.name === sp)
+    if (!speciesEntry) {
+      return Promise.reject(new Error('Unknown species: ' + sp))
+    }
+    let suit = speciesEntry.minsuit
 
     suit = suit / 100
-    spmin = 0
-    spmin = spmin / 100
-    window.dat = becStore
 
     outlist_suit = []
     outlist_non_suit = []
-    outlist_2019 = []
-    outlist_non_2019 = []
     return new Promise((resolve, reject) => {
       fetchJSON(jsontxt)
         .then(function (data) {
-          window.json_obj = data
-
           // find the name in becStore associated to the bec id chosen
-          var bec_name = becStore.find((x) => x.id == bec).name
+          var becEntryLot = becStore.find((x) => x.id == bec)
+          if (!becEntryLot) {
+            reject(new Error('Unknown BEC variant ID: ' + bec))
+            return
+          }
+          var bec_name = becEntryLot.name
           var results = data.filter(function (x) {
-            return (
-              x['BECvar_seed'] == bec_name && x['HTp_pred'] >= suit && x['Sp_suit_site'] >= spmin
-            )
+            return x['BECvar_seed'] == bec_name && x['HTp_pred'] >= suit
           })
 
           updateData(results).then(function (data) {
@@ -723,26 +697,26 @@ define(function () {
           })
 
           if (results.length == 0) {
-            alert('No results available for those parameters')
+            throw new Error('No results available for those parameters')
           }
 
           // ========= SUITABLE OUTPUT ==========
           if (output_suit.length > 0) {
             for (let i = 0; i < output_suit.length; i++) {
-              outlist_suit += "'" + output_suit[i].BECvar_site + "'" + ', '
+              outlist_suit.push("'" + output_suit[i].BECvar_site + "'")
             }
           }
-          outlist_suit = outlist_suit.slice(0, -2)
+          outlist_suit = outlist_suit.join(', ')
 
           // ========= NON SUITABLE OUTPUT ==========
           if (output_non_suit.length > 0) {
             for (let i = 0; i < output_non_suit.length; i++) {
-              outlist_non_suit += "'" + output_non_suit[i].BECvar_site + "'" + ', '
+              outlist_non_suit.push("'" + output_non_suit[i].BECvar_site + "'")
             }
           }
-          outlist_non_suit = outlist_non_suit.slice(0, -2)
+          outlist_non_suit = outlist_non_suit.join(', ')
 
-          resolve([outlist_suit, outlist_non_suit, outlist_2019, outlist_non_2019])
+          resolve([outlist_suit, outlist_non_suit])
         })
         .catch(function (errorThrown) {
           reject(new Error('Failed to load Species database: ' + errorThrown.message))
@@ -753,7 +727,7 @@ define(function () {
   function populateSeedlot(orch) {
     var jsonorch = 'Version_7_0/' + 'Orchard_list.json'
     var jsonseed = 'Version_7_0/' + 'Seedlot_list.json'
-    var results = ''
+    var results = []
 
     return new Promise((resolve, reject) => {
       fetchJSON(jsonorch)
@@ -764,43 +738,36 @@ define(function () {
           if (seedlot.length > 0) {
             document.getElementById('seedlotNumber').value = seedlot[0].Seedlot.toString()
 
-            fetchJSON(jsonseed)
+            return fetchJSON(jsonseed)
               .then(function (seed_data) {
-                new Promise((resolveInner) => {
-                  results = seed_data.filter(function (x) {
-                    return x['Orchard'] == orch || parseFloat(x['Orchard']) == parseFloat(orch)
-                  })
-                  resolveInner(results)
-                }).then(() => {
-                  window.res = results
-                  if (results && results.length > 0) {
-                    let becVarObj = results[0].BECvar
-                      ? becStore.find((x) => x.name == results[0].BECvar)
-                      : null
-                    if (window.selectBecSeedlot) {
-                      if (becVarObj) {
-                        window.selectBecSeedlot.setSelected(becVarObj.id.toString())
-                      } else {
-                        window.selectBecSeedlot.setSelected([])
-                      }
+                results = seed_data.filter(function (x) {
+                  return x['Orchard'] == orch || parseFloat(x['Orchard']) == parseFloat(orch)
+                })
+                if (results && results.length > 0) {
+                  let becVarObj = results[0].BECvar
+                    ? becStore.find((x) => x.name == results[0].BECvar)
+                    : null
+                  if (window.selectBecSeedlot) {
+                    if (becVarObj) {
+                      window.selectBecSeedlot.setSelected(becVarObj.id.toString())
+                    } else {
+                      window.selectBecSeedlot.setSelected([])
                     }
-
-                    if (window.selectSpeciesSeedlot && results[0].Species) {
-                      window.selectSpeciesSeedlot.setSelected(results[0].Species)
-                    }
-                  } else {
-                    console.warn(`No seedlots found in Seedlot_list.json for Orchard ${orch}`)
                   }
 
-                  resolve()
-                })
+                  if (window.selectSpeciesSeedlot && results[0].Species) {
+                    window.selectSpeciesSeedlot.setSelected(results[0].Species)
+                  }
+                } else {
+                  console.warn(`No seedlots found in Seedlot_list.json for Orchard ${orch}`)
+                }
+                resolve()
               })
               .catch(function (errorThrown) {
                 reject(new Error('Failed to load Seedlot database: ' + errorThrown.message))
               })
           } else {
-            alert('Not a valid option')
-            resolve()
+            reject(new Error('Not a valid option'))
           }
         })
         .catch(function (errorThrown) {
@@ -837,8 +804,7 @@ define(function () {
             }
             resolve()
           } else {
-            alert('Not a valid seedlot')
-            resolve()
+            reject(new Error('Not a valid seedlot'))
           }
         })
         .catch(function (errorThrown) {

--- a/docs/scripts/main.js
+++ b/docs/scripts/main.js
@@ -390,6 +390,13 @@ define(function () {
 
   // create the paths and locations for the selected cutblock and species
   function addSuitabilityLayerCutblock(sp, bec) {
+    if (!sp || sp === '') {
+      return Promise.reject(new Error('Please select a Species.'))
+    }
+    if (!bec || bec.length === 0) {
+      return Promise.reject(new Error('Please select a BEC Variant.'))
+    }
+
     var spmin
     var outlist_suit, outlist_non_suit, outlist_2019, outlist_non_2019
     var output_suit, output_non_suit
@@ -656,6 +663,13 @@ define(function () {
   }
 
   function addSuitabilityLayerSeedlot(sp, bec) {
+    if (!sp || sp === '') {
+      return Promise.reject(new Error('Please select a Species.'))
+    }
+    if (!bec || bec === '') {
+      return Promise.reject(new Error('Please select a BEC Variant.'))
+    }
+
     var spmin
     var outlist_suit, outlist_non_suit, outlist_2019, outlist_non_2019
     var output_suit, output_non_suit

--- a/docs/scripts/requireMain.js
+++ b/docs/scripts/requireMain.js
@@ -154,10 +154,6 @@ require(['scripts/defineMap.js', 'scripts/main.js'], function (defineMap, main) 
       })
   })
 
-  document.getElementById('mapDiv').addEventListener('click', function () {
-    defineMap.updatePopup = 'This is a test'
-  })
-
   document.getElementById('clearButtonCutblock').addEventListener('click', function () {
     defineMap.clearCutBlock()
     $('#mapLegend').fadeOut(300)

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -143,4 +143,28 @@ test.describe('CBST Seedlot Selection Tool - E2E Integration Tests', () => {
     await seedRow.waitFor({ state: 'visible', timeout: 15 * 1000 })
     await expect(seedRow).not.toContainText('No matching records found')
   })
+
+  test('Seedlot Flow: Entering Orchard 109 with unassigned BEC variant handles empty data gracefully', async ({
+    page,
+  }) => {
+    // Click the "I Have A Seedlot" tab
+    await page.click('#seedlot-tab')
+
+    // Fill in Orchard Number 109
+    await page.fill('#orchardNumber', '109')
+
+    // Click "Set Representative Seedlot"
+    page.on('dialog', async (dialog) => {
+      await dialog.accept()
+    })
+    await page.click('#addSeedlotfromOrchard')
+
+    // Verify it set the seedlot number but gracefully left/cleared BEC variant selection
+    await expect(page.locator('#seedlotNumber')).toHaveValue('3377')
+    await expect(page.locator('#speciesInputSeedlot')).toHaveValue('FDC')
+
+    // Since BEC variant is empty/unassigned, the BEC dropdown should have no selected values
+    await expect(page.locator('#becInputSeedlot')).toHaveValues([])
+  })
 })
+

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -166,5 +166,25 @@ test.describe('CBST Seedlot Selection Tool - E2E Integration Tests', () => {
     // Since BEC variant is empty/unassigned, the BEC dropdown should have no selected values
     await expect(page.locator('#becInputSeedlot')).toHaveValues([])
   })
+
+  test('Seedlot Flow: Entering Orchard 800 with float-serialized ID matches successfully', async ({
+    page,
+  }) => {
+    // Click the "I Have A Seedlot" tab
+    await page.click('#seedlot-tab')
+
+    // Fill in Orchard Number 800
+    await page.fill('#orchardNumber', '800')
+
+    // Click "Set Representative Seedlot"
+    page.on('dialog', async (dialog) => {
+      await dialog.accept()
+    })
+    await page.click('#addSeedlotfromOrchard')
+
+    // Verify it resolved Orchard "800.0", set species to YC, and handled empty BEC gracefully
+    await expect(page.locator('#speciesInputSeedlot')).toHaveValue('YC')
+    await expect(page.locator('#becInputSeedlot')).toHaveValues([])
+  })
 })
 

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -187,5 +187,27 @@ test.describe('CBST Seedlot Selection Tool - E2E Integration Tests', () => {
     await expect(page.locator('#speciesInputSeedlot')).toHaveValue('YC')
     await expect(page.locator('#becInputSeedlot')).toHaveValues([])
   })
+
+  test('Seedlot Flow: Clicking GO with empty BEC variant triggers validation error', async ({
+    page,
+  }) => {
+    // Click the "I Have A Seedlot" tab
+    await page.click('#seedlot-tab')
+
+    // Fill in Orchard Number 800 (which populates species YC but leaves BEC empty)
+    await page.fill('#orchardNumber', '800')
+    page.on('dialog', async (dialog) => {
+      await dialog.accept()
+    })
+    await page.click('#addSeedlotfromOrchard')
+
+    // Click the GO button for Seedlot with no BEC selected
+    await page.click('#addButtonSeedlot')
+
+    // Verify it displays the custom error banner "Please select a BEC Variant."
+    const errorBanner = page.locator('.alert-error-banner .alert-message-text')
+    await expect(errorBanner).toBeVisible()
+    await expect(errorBanner).toHaveText('Please select a BEC Variant.')
+  })
 })
 

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -183,6 +183,7 @@ test.describe('CBST Seedlot Selection Tool - E2E Integration Tests', () => {
     await page.click('#addSeedlotfromOrchard')
 
     // Verify it resolved Orchard "800.0", set species to YC, and handled empty BEC gracefully
+    await expect(page.locator('#seedlotNumber')).toHaveValue('V0932')
     await expect(page.locator('#speciesInputSeedlot')).toHaveValue('YC')
     await expect(page.locator('#becInputSeedlot')).toHaveValues([])
   })

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -50,5 +50,9 @@ test('Unit Tests for main.js helpers', async (t) => {
       { Sp_suit_seed: 'Not Suitable', name: 'unsuitable item' },
       { Sp_suit_seed: 'Not Suitable', name: 'other item' },
     ])
+    // Verify non-mutating behavior
+    assert.strictEqual(data[0].Sp_suit_seed, '1')
+    assert.strictEqual(data[1].Sp_suit_seed, '0')
+    assert.strictEqual(data[2].Sp_suit_seed, 'anything else')
   })
 })


### PR DESCRIPTION
## Overview

This PR resolves critical issues across CSP policies, PR preview database routing, vegetative seedlot lookups, calculation input validation, console noise, technical debt, and tab layout consistency.

### Key Improvements:

1. **CSP Inline Script Fixes**: Replaced submit-style buttons with `type="button"` and dropped inline `onclick="return false"` handlers in `docs/index.html` to eliminate CSP violations.
2. **Zero-404 Database Routing**: Dynamically detects pruned preview databases (pruned due to the 476 MB database size footprint) via a custom `data-database-pruned` attribute injected during the build workflow. Automatically routes preview requests directly to the production stable database on the first attempt, preventing browser 404 errors.
3. **Alphanumeric Vegetative Seedlot Support**: Changed `#seedlotNumber` from `type="number"` to `type="text"` and removed `parseInt()` coercion in `main.js`. This allows registered vegetative seedlots starting with letters (e.g., `"V0932"` for Orchard `800`) to be displayed and searched without triggering `NaN` console crashes.
4. **Input Validation & Crash Prevention**: Added guardrail checks to Species and BEC variant calculation triggers. If a user tries to click GO with an empty or unassigned BEC selection (common in vegetative or unassigned lots), the app gracefully renders a warning banner instead of crashing on `Cannot read properties of undefined (reading 'name')`.
5. **Technical Debt & Dead Code Removal**: Cleaned up module-polluting global variables (`window.dat`, `window.res`, `window.outlist`, `window.json_obj`). Trimmed 10 dead/orphaned functions, resolved Esri API typos (`outfields` -> `outFields`, `{MAP_Label}` -> `{MAP_LABEL}`), replaced invalid SQL `'MAP_LABEL in ()'` with `'1=0'`, refactored `updateData()` to be fully non-mutating with new unit test assertions, and replaced all browser-blocking `alert()` calls with clean Promise rejections/Error throws.
6. **Console Noise Suppression**: Added a console interceptor in `loader-init.js` that silences expected Esri CDN `FeatureSourceEventLog` / `Failed to load tile` warnings from `maps.forsite.ca`. These are benign server-side 5xx errors that ArcGIS self-heals via retry. Documented in `README.md`.
7. **CDN Cache Busting**: Bumped all CSS, Dojo module, and JS cache-busting configurations to `v=7.0.8` to force browsers and CDN edges to load the updated files immediately.
8. **Tab Layout Alignment (Option A)**: Moved "Zoom to Location" inputs and buttons to the very bottom of the **"I Have a Cutblock"** tab (below the `#cutblock_table` and `#seedlot_table` wrappers), achieving full layout parity and structural consistency with the **"I Have a Seedlot"** tab.
9. **E2E Playwright Suite Expansion**: Added dedicated Playwright integration tests covering unassigned BEC handling (Orchard `109`), float-serialized Orchard IDs (Orchard `800`), vegetative seedlot assignments (`"V0932"`), and empty BEC calculation validation. All 7 tests pass successfully.

Closes #76

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Map Preview](https://bcgov.github.io/nr-seedtransfer-map/deployments/pr-82/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-seedtransfer-map/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-seedtransfer-map/actions/workflows/merge.yml)