### PR TITLE
chore(map): remove nonsuitLayer and update map legend

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -535,18 +535,6 @@
               ></span>
               <span class="text-dark">Suitable</span>
             </div>
-            <div class="d-flex align-items-center">
-              <span
-                class="d-inline-block rounded-circle me-2"
-                style="
-                  width: 12px;
-                  height: 12px;
-                  background-color: rgba(170, 102, 205, 0.7);
-                  border: 1.5px solid rgb(76, 0, 115);
-                "
-              ></span>
-              <span class="text-dark">Borderline Suitable</span>
-            </div>
           </div>
         </div>
       </div>

--- a/docs/scripts/defineMap.js
+++ b/docs/scripts/defineMap.js
@@ -31,8 +31,8 @@ define([
   var _scaleBar
   var activeWidget
   var expand, trackWidget
-  var currentLayer, nonsuitLayer, mguLayer
-  var _suitRenderer, _nonSuitRenderer
+  var currentLayer, mguLayer
+  var _suitRenderer
   var portalUrl = 'https://www.arcgis.com'
   var template
   var uploadFormEl, uploadStatusEl
@@ -104,11 +104,6 @@ define([
       ['*'],
       'CBST',
     )
-    nonsuitLayer = featureInit(
-      'https://maps.forsite.ca/server/rest/services/Hosted/CBST_BEC10_BEC11/FeatureServer/6',
-      ['*'],
-      'CBST Species May Not Be Suitable',
-    )
 
     mguLayer = featureInit(
       'https://maps.forsite.ca/server/rest/services/Hosted/CBST_BEC10_BEC11/FeatureServer/0',
@@ -150,7 +145,6 @@ define([
       outlist.yearLayers.forEach((yearData, _index) => {
         const year = String(yearData.year)
         const suitBecList = Array.isArray(yearData.suit) ? yearData.suit : []
-        const nonSuitBecList = Array.isArray(yearData.nonSuit) ? yearData.nonSuit : []
         const color = yearColors[year] || { r: 100, g: 100, b: 100, a: 0.6 }
 
         // Create suitable layer for this year
@@ -164,33 +158,10 @@ define([
           )
           map.add(yearLayerSuit)
         }
-
-        // Create non-suitable layer for this year
-        if (nonSuitBecList.length > 0) {
-          const definitionExpr = 'MAP_LABEL in (' + nonSuitBecList.join(', ') + ')'
-          const yearLayerNonSuit = cloneLayerWithColor(
-            nonsuitLayer,
-            definitionExpr,
-            { r: color.r, g: color.g, b: color.b, a: 0.3 }, // Lighter shade for non-suitable
-            `Year ${year} - Not Suitable`,
-          )
-          map.add(yearLayerNonSuit)
-        }
       })
     } else {
       // Simple format (single year or fallback) - use original layers
       const suitList = Array.isArray(outlist) ? outlist[0] : ''
-      const nonSuitList = Array.isArray(outlist) ? outlist[1] : ''
-
-      if (nonSuitList && nonSuitList.length > 0) {
-        nonsuitLayer.definitionExpression = 'MAP_LABEL in (' + nonSuitList + ')'
-        nonsuitLayer.popupTemplate = template
-        map.add(nonsuitLayer)
-      } else {
-        nonsuitLayer.definitionExpression = '1=0'
-        nonsuitLayer.popupTemplate = ''
-        map.add(nonsuitLayer)
-      }
 
       if (suitList && suitList.length > 0) {
         currentLayer.definitionExpression = 'MAP_LABEL in (' + suitList + ')'


### PR DESCRIPTION
This PR removes the 'Not Suitable' (historically 'Borderline Suitable') map layer (nonsuitLayer) from map rendering, initialization, and layer updates as part of issue #52. Since the new ArcGIS Online server details are private (returning 403), the rest of the REST API updates are deferred until the asset is published.

The 'Borderline Suitable' legend item was also cleaned up from docs/index.html to avoid orphan legend labels.

Closes #52

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Map Preview](https://bcgov.github.io/nr-seedtransfer-map/deployments/pr-90/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-seedtransfer-map/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-seedtransfer-map/actions/workflows/merge.yml)