### PR TITLE
fix(ci): make PR preview cleanup reliable and self-healing

### DIFF
--- a/.github/scripts/prune-previews.sh
+++ b/.github/scripts/prune-previews.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Remove deployments/pr-<N> preview folders from the gh-pages branch WITHOUT
+# downloading the multi-gigabyte FlatGeobuf blobs they contain.
+#
+# Why: the old cleanup checked out the entire gh-pages branch (now several GB)
+# just to delete one folder. That was slow, grew with the branch, and could
+# time out — leaving orphaned previews that bloated gh-pages until the GitHub
+# Pages build failed. Deleting a folder only needs commit/tree metadata, so a
+# blobless (--filter=blob:none) no-checkout clone lets us rebuild the tree and
+# push only the deletion in seconds, regardless of branch size.
+#
+# Usage:  prune-previews.sh <pr-number> [<pr-number> ...]
+# Env:    GH_TOKEN  token with contents:write on the repo
+#         REPO      owner/name (e.g. bcgov/nr-seedtransfer-map)
+#
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+  echo "usage: $0 <pr-number> [<pr-number> ...]" >&2
+  exit 2
+fi
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${REPO:?REPO is required}"
+
+# Identity for git commit-tree, supplied via env (no global config mutation).
+export GIT_AUTHOR_NAME="github-actions[bot]"
+export GIT_AUTHOR_EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
+export GIT_COMMITTER_NAME="github-actions[bot]"
+export GIT_COMMITTER_EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+# Metadata-only clone: trees and commits, but no file blobs.
+git clone --filter=blob:none --no-checkout --depth 1 \
+  --branch gh-pages --single-branch \
+  "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "$workdir"
+cd "$workdir"
+
+# Retry loop so a concurrent gh-pages mutation (a deploy) can't make us fail.
+for attempt in 1 2 3 4 5; do
+  git fetch --filter=blob:none --depth 1 origin gh-pages
+  parent="$(git rev-parse FETCH_HEAD)"
+
+  tmp_index="$(mktemp)"
+  GIT_INDEX_FILE="$tmp_index" git read-tree "$parent"
+
+  removed=0
+  for pr in "$@"; do
+    dir="deployments/pr-${pr}"
+    if GIT_INDEX_FILE="$tmp_index" git ls-files --error-unmatch "$dir" >/dev/null 2>&1; then
+      GIT_INDEX_FILE="$tmp_index" git rm -r --cached --quiet "$dir"
+      echo "🧹 staged removal: $dir"
+      removed=$((removed + 1))
+    fi
+  done
+
+  if [ "$removed" -eq 0 ]; then
+    rm -f "$tmp_index"
+    echo "ℹ️ No matching preview folders on gh-pages — nothing to remove."
+    exit 0
+  fi
+
+  new_tree="$(GIT_INDEX_FILE="$tmp_index" git write-tree)"
+  rm -f "$tmp_index"
+
+  if [ "$removed" -eq 1 ]; then
+    msg="chore(deployments): remove preview for closed PR (1 folder)"
+  else
+    msg="chore(deployments): remove previews for ${removed} closed PRs"
+  fi
+  new_commit="$(git commit-tree "$new_tree" -p "$parent" -m "$msg")"
+
+  if git push origin "${new_commit}:gh-pages"; then
+    echo "✅ Removed ${removed} preview folder(s) from gh-pages."
+    exit 0
+  fi
+
+  echo "::warning::gh-pages advanced during push; retrying (${attempt}/5)..."
+  sleep "$((attempt * 5))"
+done
+
+echo "::error::Failed to push gh-pages cleanup after 5 attempts." >&2
+exit 1

--- a/.github/scripts/prune-previews.sh
+++ b/.github/scripts/prune-previews.sh
@@ -77,8 +77,10 @@ for attempt in 1 2 3 4 5; do
     exit 0
   fi
 
-  echo "::warning::gh-pages advanced during push; retrying (${attempt}/5)..."
-  sleep "$((attempt * 5))"
+  if [ "$attempt" -lt 5 ]; then
+    echo "::warning::gh-pages advanced during push; retrying (${attempt}/5)..."
+    sleep "$((attempt * 5))"
+  fi
 done
 
 echo "::error::Failed to push gh-pages cleanup after 5 attempts." >&2

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -1,9 +1,15 @@
-name: PR Cleanup
+name: PR Preview Cleanup
 
 on:
   pull_request:
     types: [closed]
+  # Daily backstop: reconcile gh-pages against open PRs so a missed or raced
+  # close event can never leave an orphaned preview to bloat the branch.
+  schedule:
+    - cron: '17 8 * * *'
+  workflow_dispatch:
 
+# Serialize all gh-pages mutations across pr-open, pr-close, and merge.
 concurrency:
   group: gh-pages-state
   cancel-in-progress: false
@@ -12,27 +18,62 @@ permissions: {}
 
 jobs:
   cleanup:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    name: Remove preview for closed PR
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: write
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: gh-pages
-
-      - name: Clean up preview folder
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+      - name: Remove preview folder
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          
-          PREVIEW_DIR="deployments/pr-${{ github.event.number }}"
-          if [ -d "$PREVIEW_DIR" ]; then
-            echo "🧹 Deleting preview folder: $PREVIEW_DIR"
-            rm -rf "$PREVIEW_DIR"
-            git add -A
-            git commit -m "chore(deployments): remove sandbox preview for PR #${{ github.event.number }}"
-            git push origin gh-pages
-          else
-            echo "ℹ️ No preview folder found to delete."
+          chmod +x .github/scripts/prune-previews.sh
+          .github/scripts/prune-previews.sh "${{ github.event.number }}"
+
+  sweep:
+    name: Sweep orphaned previews
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+      - name: Remove previews for closed PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          chmod +x .github/scripts/prune-previews.sh
+
+          closed=()
+          while read -r name; do
+            case "$name" in
+              pr-*) num="${name#pr-}" ;;
+              *) continue ;;
+            esac
+            [[ "$num" =~ ^[0-9]+$ ]] || continue
+            state="$(gh api "repos/${REPO}/pulls/${num}" --jq '.state' 2>/dev/null || echo '')"
+            if [ "$state" = "closed" ]; then
+              echo "PR #${num} is closed → flagging preview for removal"
+              closed+=("$num")
+            fi
+          done < <(gh api "repos/${REPO}/contents/deployments?ref=gh-pages" --jq '.[].name' 2>/dev/null || true)
+
+          if [ "${#closed[@]}" -eq 0 ]; then
+            echo "✅ No orphaned previews found."
+            exit 0
           fi
+
+          .github/scripts/prune-previews.sh "${closed[@]}"

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -68,6 +68,18 @@ jobs:
         run: |
           chmod +x .github/scripts/prune-previews.sh
 
+          list_file=$(mktemp)
+          err_file=$(mktemp)
+          if ! gh api "repos/${REPO}/contents/deployments?ref=gh-pages" --jq '.[].name' >"$list_file" 2>"$err_file"; then
+            if grep -qE '404|Not Found' "$err_file"; then
+              echo "✅ No deployments/ folder on gh-pages — nothing to sweep."
+              exit 0
+            fi
+            cat "$err_file" >&2
+            echo "::error::Failed to list deployments/ on gh-pages" >&2
+            exit 1
+          fi
+
           closed=()
           while read -r name; do
             case "$name" in
@@ -80,7 +92,7 @@ jobs:
               echo "PR #${num} is closed → flagging preview for removal"
               closed+=("$num")
             fi
-          done < <(gh api "repos/${REPO}/contents/deployments?ref=gh-pages" --jq '.[].name' 2>/dev/null || true)
+          done < "$list_file"
 
           if [ "${#closed[@]}" -eq 0 ]; then
             echo "✅ No orphaned previews found."

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -9,10 +9,13 @@ on:
     - cron: '17 8 * * *'
   workflow_dispatch:
 
-# Serialize all gh-pages mutations across pr-open, pr-close, and merge.
+# Workflow-level: share pr-open's per-PR group so closing a PR CANCELS its
+# in-flight open/deploy run. Without this the deploy could finish after the
+# cleanup and re-create the folder. (Each gh-pages-mutating job below also
+# joins the gh-pages-state group to serialize the actual push against merge.yml.)
 concurrency:
-  group: gh-pages-state
-  cancel-in-progress: false
+  group: pr-preview-${{ github.event.number }}
+  cancel-in-progress: true
 
 permissions: {}
 
@@ -24,6 +27,10 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: write
+    # Serialize the actual gh-pages push against pr-open's deploy and merge.yml.
+    concurrency:
+      group: gh-pages-state
+      cancel-in-progress: false
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
@@ -44,6 +51,10 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
+    # Serialize the actual gh-pages push against pr-open's deploy and merge.yml.
+    concurrency:
+      group: gh-pages-state
+      cancel-in-progress: false
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

The PR preview cleanup workflow has been silently leaking preview folders on `gh-pages`. Roughly **11 closed-PR previews** accumulated (~5 GB), which — combined with the full-FGB previews — pushed `gh-pages` to **11.2 GB** and **broke the GitHub Pages build** (the live site froze on a stale build and started serving 404s).

Root causes in the old `pr-close.yml`:
- It ran `actions/checkout` on the **entire** `gh-pages` branch (several GB and growing) just to delete one folder — slow (~2 min) and increasingly likely to time out.
- **No retry** if a concurrent deploy advanced `gh-pages` between checkout and push.
- It reported **success** even when it no-oped or when a still-in-flight deploy re-created the folder after close.

## Changes

- **`.github/scripts/prune-previews.sh`** — removes `deployments/pr-<N>` folders using a **blobless (`--filter=blob:none`) no-checkout clone**: it rebuilds the tree with the folder removed and pushes only the deletion. No multi-GB blob downloads, so it runs in seconds regardless of branch size. Includes a fetch + retry loop (5 attempts) to survive concurrent `gh-pages` pushes. Accepts one or many PR numbers (single commit).
- **`.github/workflows/pr-close.yml`** — rewritten to:
  - `cleanup` job: invoke the script on PR close (fast, robust).
  - `sweep` job: **daily** (`cron`) + `workflow_dispatch` reconciliation that lists preview folders on `gh-pages`, checks each PR's state, and removes any whose PR is **closed**. This is a self-healing backstop so a missed/raced close event can never orphan a preview again.

Both jobs keep the shared `gh-pages-state` concurrency group so all `gh-pages` mutations stay serialized across `pr-open`, `pr-close`, and `merge`.

> Note: the existing ~5 GB backlog was already removed manually while restoring the failing Pages build; this PR prevents recurrence and cleans up automatically going forward.

## Test plan

- [x] `bash -n` + `shellcheck` clean on `prune-previews.sh`
- [x] YAML parses
- [x] Dry-run against the live repo with a non-existent PR number: blobless clone + tree read succeed, exits cleanly with no push
- [ ] After merge: trigger the `sweep` job via **Run workflow** and confirm it reports no orphans (backlog already clear)
- [ ] On the next PR close, confirm the `cleanup` job removes the folder in seconds

Made with [Cursor](https://cursor.com)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Map Preview](https://bcgov.github.io/nr-seedtransfer-map/deployments/pr-102/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-seedtransfer-map/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-seedtransfer-map/actions/workflows/merge.yml)