### PR TITLE
chore(data): archive Forsite polygon source data before contract shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,7 @@ docs/Version_7_0/*.fgb
 # Forsite contract is ending, so these cannot be recompiled — see scripts/export-layers-to-fgb.js)
 !docs/Version_7_0/Management_Units.fgb
 !docs/Version_7_0/BEC_Variants.fgb
+
+# Ignore local GeoJSON polygon cache
+data/source/polygons/*.geojson
+

--- a/README.md
+++ b/README.md
@@ -136,6 +136,30 @@ npm run format
 
 ---
 
+## Polygon Data & Provenance
+
+The interactive map is driven by static FlatGeobuf (`.fgb`) files served from the `docs/Version_7_0/` directory, completely decoupling runtime operations from external API servers.
+
+### Archiving and Rebuilding the FGB Assets
+
+The original source data for the Biogeoclimatic Ecosystem Classification (BEC 10/11) variants and Management Units was provided by the Forsite ArcGIS FeatureServer. Because that server contract has ended, the raw GeoJSON files have been locally archived in the `data/source/polygons/` directory.
+
+To rebuild the FlatGeobuf assets from the local GeoJSON cache:
+
+```bash
+npm run polygons:export
+```
+
+**Metadata:**
+The `data/source/polygons/EXPORT_METADATA.json` file records exactly when the data was exported from the Forsite server, the number of features retrieved, and the original endpoint URLs. The raw `*.geojson` files themselves are `.gitignore`d to prevent repository bloat, but they are stored as offline backups and expected to be present locally if you wish to run the export script.
+
+If you ever need to fetch live data (while the server is still available), you can run the script manually with the fetch flag:
+```bash
+node scripts/export-layers-to-fgb.js --fetch-live
+```
+
+---
+
 ## Repository Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -138,22 +138,30 @@ npm run format
 
 ## Polygon Data & Provenance
 
-The interactive map is driven by static FlatGeobuf (`.fgb`) files served from the `docs/Version_7_0/` directory, completely decoupling runtime operations from external API servers.
+The interactive map is driven by static FlatGeobuf (`.fgb`) files served from the
+`docs/Version_7_0/` directory, completely decoupling runtime operations from external API servers.
 
 ### Archiving and Rebuilding the FGB Assets
 
-The original source data for the Biogeoclimatic Ecosystem Classification (BEC 10/11) variants and Management Units was provided by the Forsite ArcGIS FeatureServer. Because that server contract has ended, the raw GeoJSON files have been locally archived in the `data/source/polygons/` directory.
+The original source data for the Biogeoclimatic Ecosystem Classification (BEC 10/11) variants and
+Management Units is provided by the Forsite ArcGIS FeatureServer. Because that server contract is
+ending, the raw GeoJSON files have been backed up.
 
-To rebuild the FlatGeobuf assets from the local GeoJSON cache:
+To rebuild the FlatGeobuf assets, you must first obtain the GeoJSON cache
+(`management_units.geojson` and `bec_variants.geojson`) from the team's offline storage and place
+them in the `data/source/polygons/` directory, as they are `.gitignore`d to prevent repository
+bloat. Then run:
 
 ```bash
 npm run polygons:export
 ```
 
-**Metadata:**
-The `data/source/polygons/EXPORT_METADATA.json` file records exactly when the data was exported from the Forsite server, the number of features retrieved, and the original endpoint URLs. The raw `*.geojson` files themselves are `.gitignore`d to prevent repository bloat, but they are stored as offline backups and expected to be present locally if you wish to run the export script.
+**Metadata:** The `data/source/polygons/EXPORT_METADATA.json` file records exactly when the data was
+exported from the Forsite server, the number of features retrieved, and the original endpoint URLs.
 
-If you ever need to fetch live data (while the server is still available), you can run the script manually with the fetch flag:
+If you ever need to fetch live data (while the server is still available), you can run the script
+manually with the fetch flag to generate the cache locally:
+
 ```bash
 node scripts/export-layers-to-fgb.js --fetch-live
 ```

--- a/data/source/polygons/EXPORT_METADATA.json
+++ b/data/source/polygons/EXPORT_METADATA.json
@@ -1,0 +1,9 @@
+{
+  "exportedAt": "2026-06-25T02:00:35.885Z",
+  "sourceUrlBase": "https://maps.forsite.ca/server/rest/services/Hosted/CBST_BEC10_BEC11/FeatureServer",
+  "features": {
+    "management_units": 724,
+    "bec_variants": 15266
+  },
+  "gitSha": "bcfb315f37d5f49e1fa1cb6a9b8fd06a4beb3506"
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "http-server docs -p 8000",
     "db:convert": "node scripts/convert-to-fgb.js",
+    "polygons:export": "node scripts/export-layers-to-fgb.js",
     "format": "prettier --write \"docs/**/*.{js,css,html}\" README.md",
     "format:check": "prettier --check \"docs/**/*.{js,css,html}\" README.md",
     "lint": "eslint docs/scripts",

--- a/scripts/export-layers-to-fgb.js
+++ b/scripts/export-layers-to-fgb.js
@@ -1,5 +1,10 @@
 const fs = require('fs');
 const path = require('path');
+const { execSync } = require('child_process');
+
+const fetchLive = process.argv.includes('--fetch-live');
+const sourceDir = path.join(__dirname, '../data/source/polygons');
+const outputDir = path.join(__dirname, '../docs/Version_7_0');
 
 async function fetchAllFeatures(layerId, outFields = '*') {
   let features = [];
@@ -42,6 +47,30 @@ async function fetchAllFeatures(layerId, outFields = '*') {
   };
 }
 
+function ensureDirSync(dir) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+async function getLayer(layerId, outFields, filename) {
+  const filePath = path.join(sourceDir, filename);
+  if (fetchLive) {
+    console.log(`Downloading Layer ${layerId} from Forsite API...`);
+    const layer = await fetchAllFeatures(layerId, outFields);
+    ensureDirSync(sourceDir);
+    fs.writeFileSync(filePath, JSON.stringify(layer, null, 2));
+    console.log(`Saved Layer ${layerId} GeoJSON to ${filePath}`);
+    return layer;
+  } else {
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`GeoJSON cache missing: ${filePath}. Run with --fetch-live to download.`);
+    }
+    console.log(`Loading Layer ${layerId} from ${filePath}...`);
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  }
+}
+
 (async () => {
   try {
     // Dynamically import ES modules from flatgeobuf package
@@ -54,8 +83,6 @@ async function fetchAllFeatures(layerId, outFields = '*') {
     const { Header } = await import('flatgeobuf/lib/mjs/flat-geobuf/header.js');
     const { Column } = await import('flatgeobuf/lib/mjs/flat-geobuf/column.js');
     const { Crs } = await import('flatgeobuf/lib/mjs/flat-geobuf/crs.js');
-
-    const outputDir = path.join(__dirname, '../docs/Version_7_0');
 
     // Helper to build header
     function customBuildHeader(t, r = 0) {
@@ -255,10 +282,11 @@ async function fetchAllFeatures(layerId, outFields = '*') {
       return result;
     }
 
+    ensureDirSync(outputDir);
+
     // 1. Layer 0 (Management Units)
-    console.log('Downloading Layer 0 (Management Units)...');
-    const l0 = await fetchAllFeatures(0, '*');
-    console.log(`Layer 0 fetched: ${l0.features.length} features. Serializing to FlatGeobuf...`);
+    const l0 = await getLayer(0, '*', 'management_units.geojson');
+    console.log(`Layer 0 loaded: ${l0.features.length} features. Serializing to FlatGeobuf...`);
     const fgb0 = serializeWithIndex(l0);
     fs.writeFileSync(path.join(outputDir, 'Management_Units.fgb'), Buffer.from(fgb0));
     console.log('Layer 0 saved to Management_Units.fgb');
@@ -280,17 +308,9 @@ async function fetchAllFeatures(layerId, outFields = '*') {
       }
     }
 
-    // 2. BEC variant polygons (FeatureServer layer 5: BEC_10_Suit_v4).
-    //
-    // Layer 6 (BEC_10_NotSuit_v4) is byte-identical to layer 5 on Forsite — same
-    // 15,266 features and total area. Suitable vs non-suitable is determined at
-    // runtime by MAP_LABEL filtering, not by layer, so we export once as
-    // BEC_Variants.fgb (see defineMap.js).
-    console.log('Downloading Layer 5 (BEC variants)...');
-    const becVariants = await fetchAllFeatures(5, 'map_label');
-    console.log(
-      `Layer 5 fetched: ${becVariants.features.length} features. Processing bounds...`,
-    );
+    // 2. Layer 5 (BEC variants)
+    const becVariants = await getLayer(5, 'map_label', 'bec_variants.geojson');
+    console.log(`Layer 5 loaded: ${becVariants.features.length} features. Processing bounds...`);
     for (const f of becVariants.features) {
       addBbox(f.properties.map_label, f.geometry);
     }
@@ -302,6 +322,21 @@ async function fetchAllFeatures(layerId, outFields = '*') {
     // Save bounds
     fs.writeFileSync(path.join(outputDir, 'bec_bounds.json'), JSON.stringify(bounds, null, 2));
     console.log(`Calculated bounds for ${Object.keys(bounds).length} variants.`);
+
+    if (fetchLive) {
+      const gitSha = execSync('git rev-parse HEAD').toString().trim();
+      const meta = {
+        exportedAt: new Date().toISOString(),
+        sourceUrlBase: 'https://maps.forsite.ca/server/rest/services/Hosted/CBST_BEC10_BEC11/FeatureServer',
+        features: {
+          management_units: l0.features.length,
+          bec_variants: becVariants.features.length
+        },
+        gitSha: gitSha
+      };
+      fs.writeFileSync(path.join(sourceDir, 'EXPORT_METADATA.json'), JSON.stringify(meta, null, 2));
+      console.log('Wrote EXPORT_METADATA.json');
+    }
 
     console.log('🎉 All layers exported and serialized successfully with spatial indexes!');
   } catch (err) {

--- a/scripts/export-layers-to-fgb.js
+++ b/scripts/export-layers-to-fgb.js
@@ -324,7 +324,12 @@ async function getLayer(layerId, outFields, filename) {
     console.log(`Calculated bounds for ${Object.keys(bounds).length} variants.`);
 
     if (fetchLive) {
-      const gitSha = execSync('git rev-parse HEAD').toString().trim();
+      let gitSha = 'unknown';
+      try {
+        gitSha = execSync('git rev-parse HEAD', { stdio: 'pipe' }).toString().trim();
+      } catch (e) {
+        console.warn('Warning: Could not determine git SHA. Proceeding with unknown.');
+      }
       const meta = {
         exportedAt: new Date().toISOString(),
         sourceUrlBase: 'https://maps.forsite.ca/server/rest/services/Hosted/CBST_BEC10_BEC11/FeatureServer',


### PR DESCRIPTION
Closes #100.
Archives the Forsite BEC 10/11 polygon source data into a local gitignored cache before the maps.forsite.ca API shuts down. Refactors the export script to support compiling FGB files entirely offline.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Map Preview](https://bcgov.github.io/nr-seedtransfer-map/deployments/pr-112/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-seedtransfer-map/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-seedtransfer-map/actions/workflows/merge.yml)